### PR TITLE
增加词条：更新 `设置 - 安全日志` 页面

### DIFF
--- a/locals.js
+++ b/locals.js
@@ -4741,6 +4741,13 @@ I18N["zh-CN"]["settings/security-log"] = { // 设置 - 安全日志
             "Created GitHub Pages site in": "创建了 GitHub Pages 在",
             "Modified GitHub Pages source in": "修改了 GitHub Pages 源代码在",
             "Created environment": "创造环境",
+            "Added": "添加",
+            "to the": "至",
+            "repository": "仓库",
+            "Added the following repositories to the": "添加以下仓库到",
+            "integration:": "集成：",
+            "Enabled GitHub Actions for": "启用仓库操作：",
+            "Created a secret for": "创建机密：",
 
     },
     "regexp": [ // 正则翻译

--- a/locals.js
+++ b/locals.js
@@ -4724,6 +4724,8 @@ I18N["zh-CN"]["settings/security-log"] = { // 设置 - 安全日志
             "Events matching search query": "搜索查询匹配结果",
             "Export": "导出",
             "Recent events": "最近的事件",
+            "Unknown IP address": "未知 IP 地址",
+            "Unknown location": "未知位置",
             // [/Found (\d+) events?/, "发现 $1 个活动"],
             "Newer": "新的",
             "Older": "旧的",
@@ -4736,6 +4738,9 @@ I18N["zh-CN"]["settings/security-log"] = { // 设置 - 安全日志
             "User signed in from an unrecognized device and location.": "用户从无法识别的设备与位置登录。",
             "New Device Used": "使用新设备",
             "Created the repository": "创建了仓库",
+            "Created GitHub Pages site in": "创建了 GitHub Pages 在",
+            "Modified GitHub Pages source in": "修改了 GitHub Pages 源代码在",
+            "Created environment": "创造环境",
 
     },
     "regexp": [ // 正则翻译

--- a/locals.js
+++ b/locals.js
@@ -4716,6 +4716,8 @@ I18N["zh-CN"]["settings/security-log"] = { // 设置 - 安全日志
                 "Copilot activity": "Copilot 活动",
                 "Personal access token activity": "个人访问令牌活动",
                 "View advanced search syntax": "查看高级搜索语法",
+            "Filter by Member": "按用户筛选",
+            "Filter by Action": "按事件筛选",
             "Search audit logs": "搜索审计日志",
             "Search your security log": "搜索您的安全日志",
             "Clear current search query": "清除当前的搜索查询",
@@ -4728,7 +4730,12 @@ I18N["zh-CN"]["settings/security-log"] = { // 设置 - 安全日志
             "ProTip!": "专业提示！",
                 "View all events created yesterday": "查看昨天创建的所有事件",
                 "View all events where you created something": "查看所有您创建内容时产生的事件",
-                "Country changed from your previous session": "“国家/地区” 与上一次会话有所不同",
+            "Country changed from your previous session": "国家或地区与上一次会话有所不同",
+            "Logged in": "登录",
+            "User signed in from an unrecognized device.": "用户从无法识别的设备登录。",
+            "User signed in from an unrecognized device and location.": "用户从无法识别的设备与位置登录。",
+            "New Device Used": "使用新设备",
+            "Created the repository": "创建了仓库",
 
     },
     "regexp": [ // 正则翻译


### PR DESCRIPTION
大号没了，继续用小号交 PR（
这次的 PR 内容不算很多，甚至还是在 web editor 没有高亮的环境下写的（vscode 莫名其妙不能往小号仓库交 commit，可能配置还是我大号的，也懒得改了）
本次更新界面：
![image](https://github.com/user-attachments/assets/391e51ca-679e-4675-a544-b68db8ad0dc7)
@maboloshi 