### PR TITLE
增加词条：新版议题页

### DIFF
--- a/locals.js
+++ b/locals.js
@@ -884,6 +884,9 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
                     "Done, closed, fixed, resolved": "已完成、已关闭、已修复、已解决",
                 "Close as not planned": "非计划中关闭",
                     "Won't fix, can't repro, duplicate, stale": "不会修复，无法重现，重复，陈旧",
+                    "Won't fix, can't repro, stale": "不会修复，无法重现，陈旧", // 新版议题页
+                // 因重复而关闭（新版议题页）
+                    "Duplicate of another issue": "重复议题",
             "Close with comment": "评论并关闭", // 议题/拉取请求 评论框
             "Close pull request": "关闭拉取请求", // 拉取请求页 评论框
             "Reopen discussion": "重新打开讨论", // discussion页 评论框
@@ -8126,7 +8129,16 @@ I18N["zh-CN"]["repository/issues"] = { // 仓库 - 议题页面
             // 子级议题
             "Create sub-issue": "创建子议题",
                 "Create sub-issue": "创建子议题",
+                    // 窗口
+                        "Create new issue": "新建议题",
+                            "Select an item": "选择一项",
+                                "Select repository": "选择仓库",
+                            "Templates and forms": "模板和表单",
+                                // 空白议题
+                                    "Create a new issue from scratch": "从头开始创建新议题",
                 "Add existing issue": "添加现有议题",
+                    "Search issues": "搜索议题",
+                        "Group selected": "分组选择",
 
                 "Blank issue": "空白议题",
                     "in": "在",
@@ -8275,6 +8287,10 @@ I18N["zh-CN"]["repository/issues"] = { // 仓库 - 议题页面
                     "for this issue or link a pull request.": "为这个议题或关联一个拉取请求",
                     "When branches are created from issues, their pull requests are automatically linked.": "当从议题中创建分支时，它们的拉取请求会自动关联。",
                     "Open in Workspace": "在工作区打开",
+
+                    // 关系
+                        "Add parent": "添加父议题",
+                        "Select a repository": "选择一个仓库",
 
                     // 参与者数大于2
                         "and others": "等",

--- a/locals.js
+++ b/locals.js
@@ -8128,7 +8128,7 @@ I18N["zh-CN"]["repository/issues"] = { // 仓库 - 议题页面
             "Parent:": "父级：",
             // 子级议题
             "Create sub-issue": "创建子议题",
-                "Create sub-issue": "创建子议题",
+                //"Create sub-issue": "创建子议题",
                     // 窗口
                         "Create new issue": "新建议题",
                             "Select an item": "选择一项",


### PR DESCRIPTION
（Copilot 总结再翻译测试）
此拉取请求包括对 `locals.js` 文件中中文（zh-CN）本地化的更新，特别是针对与问题和拉取请求相关的各种术语和短语的翻译。最重要的变化包括添加了用于问题页面的术语的新翻译和现有翻译的改进。

议题相关翻译的更新：

* 添加了用于更新问题页面的术语的新翻译，例如“无法修复，无法重现，过时”和“重复的另一个议题”。
* 引入了创建和管理议题的翻译，包括“创建新问题”、“选择项目”、“选择仓库”、“模板和表单”、“从头开始创建新议题”、“搜索议题”和“分组选定的”。
* 添加了关系管理术语的翻译，例如“添加父级”和“选择一个仓库”。

（原文）
This pull request includes updates to the Chinese (zh-CN) localization in the `locals.js` file, specifically targeting the translation of various terms and phrases related to issues and pull requests. The most important changes include the addition of new translations for terms used in the issue pages and the refinement of existing translations.

Updates to issue-related translations:

* Added new translations for terms used in the updated issue page, such as "Won't fix, can't repro, stale" and "Duplicate of another issue".
* Introduced translations for creating and managing issues, including "Create new issue", "Select an item", "Select repository", "Templates and forms", "Create a new issue from scratch", "Search issues", and "Group selected".
* Added translations for relationship management terms like "Add parent" and "Select a repository".