### PR TITLE
修复: 仅在翻译文本存在时更新页面标题

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -364,7 +364,9 @@
                 if (translatedText !== text) break;
             }
         }
-        document.title = translatedText;
+        if (translatedText) {
+            document.title = translatedText;
+        }
     }
 
     /**


### PR DESCRIPTION
防止当没有匹配的翻译时，页面标题被设为空的问题。