### PR TITLE
fix(i18n): 补充状态弹窗等场景的 11 条缺失词条（同步 zh-TW）

### DIFF
--- a/locals(greasyfork).js
+++ b/locals(greasyfork).js
@@ -883,6 +883,7 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
         // 状态设置对话框
         // 出现位置: 个人资料页, Gist 个人主页, 仓库页右上角个人图标下拉菜单
             "Edit status": "编辑状态",
+            "What's happening": "发生了什么",
             "What's happening?": "发生了什么？",
 
             "Suggestions": "建议",
@@ -896,6 +897,7 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
                 "I may be slow to respond.": "我的回复可能比较慢。",
 
             "Clear status": "清除状态",
+                "Expiration": "有效期",
                 "Never": "永不",
                 "in 30 minutes": "30 分钟",
                 "in 1 hour": "1 小时",
@@ -904,8 +906,10 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
                 "after this week": "本周之后",
                 "after a month": "本月之后",
                 "How long until this status will automatically clear.": "多久后状态自动清除。",
+                "Your status will be cleared after the selected time.": "在所选时间后，您的状态将被清除。",
             "Visible to": "可见",
                 "Everyone": "任何人",
+                    "Limit status visibility to a single organization.": "将状态可见范围限制为单个组织。",
                     "Scope status visibility to a single organization.": "将状态可视范围扩大到单个组织。",
             "Filter emoji": "筛选表情符号",
                 "Search results": "筛选结果",
@@ -1525,6 +1529,7 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
                         "Choose a repository to chat about.": "选择以聊天",
                 "Remove topic": "移除主题",
                 "Add repositories, files, and spaces": "添加仓库、文件和空间",
+                "Add files, and spaces": "添加文件和空间",
                 "Upload from computer": "上传本机文件",
                 "Files and folders": "文件和文件夹",
                 "Spaces…": "空间…",
@@ -2416,6 +2421,7 @@ I18N["zh-CN"]["page-dashboard"] = { // 已登录的首页 - 仪表板（含组�
         [/Good evening, ([^ ]+)!/, "晚上好，$1！"],
         [/Switch dashboard: ([^ ]+)/, "切换仪表板：$1"],
         [/(.+)\#(\d+) · Opened by ([^ ]+) ·/, "$1#$2 · 打开者 $3"],
+        [/(\d+) characters remaining/, "还可输入 $1 个字符"],
     ],
     "title": {
         "static": {
@@ -8719,6 +8725,9 @@ I18N["zh-CN"]["repository"] = { // 仓库页面 /<user-name>/<repo-name>/
 
                 // 提交栏 GitHub Action
                 "All checks have passed": "已通过所有检查",
+                "View status": "查看状态",
+                "What's new": "新变化",
+                "Switch to the classic experience": "切换到经典体验",
 
 
                 // 关注 & 订阅通知设置 下拉菜单
@@ -10375,8 +10384,10 @@ I18N["zh-CN"]["repository/issues"] = { // 仓库 - 议题页面
 
             "New label": "新建标签",
                 "Label preview": "标签预览",
+                "Name": "名称",
                 "Label name": "标签名",
                 "Description": "描述",
+                "Optionally add a description": "可选添加描述",
                 "Description (optional)": "描述（可选）",
                 "Color": "颜色",
                     "Get a new color": "获得新颜色",

--- a/locals.js
+++ b/locals.js
@@ -883,6 +883,7 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
         // 状态设置对话框
         // 出现位置: 个人资料页, Gist 个人主页, 仓库页右上角个人图标下拉菜单
             "Edit status": "编辑状态",
+            "What's happening": "发生了什么",
             "What's happening?": "发生了什么？",
 
             "Suggestions": "建议",
@@ -896,6 +897,7 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
                 "I may be slow to respond.": "我的回复可能比较慢。",
 
             "Clear status": "清除状态",
+                "Expiration": "有效期",
                 "Never": "永不",
                 "in 30 minutes": "30 分钟",
                 "in 1 hour": "1 小时",
@@ -904,8 +906,10 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
                 "after this week": "本周之后",
                 "after a month": "本月之后",
                 "How long until this status will automatically clear.": "多久后状态自动清除。",
+                "Your status will be cleared after the selected time.": "在所选时间后，您的状态将被清除。",
             "Visible to": "可见",
                 "Everyone": "任何人",
+                    "Limit status visibility to a single organization.": "将状态可见范围限制为单个组织。",
                     "Scope status visibility to a single organization.": "将状态可视范围扩大到单个组织。",
             "Filter emoji": "筛选表情符号",
                 "Search results": "筛选结果",
@@ -1525,6 +1529,7 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
                         "Choose a repository to chat about.": "选择以聊天",
                 "Remove topic": "移除主题",
                 "Add repositories, files, and spaces": "添加仓库、文件和空间",
+                "Add files, and spaces": "添加文件和空间",
                 "Upload from computer": "上传本机文件",
                 "Files and folders": "文件和文件夹",
                 "Spaces…": "空间…",
@@ -2417,6 +2422,7 @@ I18N["zh-CN"]["page-dashboard"] = { // 已登录的首页 - 仪表板（含组�
         [/Good evening, ([^ ]+)!/, "晚上好，$1！"],
         [/Switch dashboard: ([^ ]+)/, "切换仪表板：$1"],
         [/(.+)\#(\d+) · Opened by ([^ ]+) ·/, "$1#$2 · 打开者 $3"],
+        [/(\d+) characters remaining/, "还可输入 $1 个字符"],
     ],
     "title": {
         "static": {
@@ -8721,6 +8727,9 @@ I18N["zh-CN"]["repository"] = { // 仓库页面 /<user-name>/<repo-name>/
 
                 // 提交栏 GitHub Action
                 "All checks have passed": "已通过所有检查",
+                "View status": "查看状态",
+                "What's new": "新变化",
+                "Switch to the classic experience": "切换到经典体验",
 
 
                 // 关注 & 订阅通知设置 下拉菜单
@@ -10378,8 +10387,10 @@ I18N["zh-CN"]["repository/issues"] = { // 仓库 - 议题页面
 
             "New label": "新建标签",
                 "Label preview": "标签预览",
+                "Name": "名称",
                 "Label name": "标签名",
                 "Description": "描述",
+                "Optionally add a description": "可选添加描述",
                 "Description (optional)": "描述（可选）",
                 "Color": "颜色",
                     "Get a new color": "获得新颜色",

--- a/locals_zh-TW.js
+++ b/locals_zh-TW.js
@@ -883,6 +883,7 @@ I18N["zh-TW"]["public"] = { // 公共區域翻譯
         // 狀態設置對話框
         // 出現位置: 個人資料頁, Gist 個人主頁, 倉庫頁右上角個人圖標下拉菜單
             "Edit status": "編輯狀態",
+            "What's happening": "發生了什麼",
             "What's happening?": "發生了什麼？",
 
             "Suggestions": "建議",
@@ -896,6 +897,7 @@ I18N["zh-TW"]["public"] = { // 公共區域翻譯
                 "I may be slow to respond.": "我的回覆可能比較慢。",
 
             "Clear status": "清除狀態",
+                "Expiration": "有效期",
                 "Never": "永不",
                 "in 30 minutes": "30 分鐘",
                 "in 1 hour": "1 小時",
@@ -904,8 +906,10 @@ I18N["zh-TW"]["public"] = { // 公共區域翻譯
                 "after this week": "本週之後",
                 "after a month": "本月之後",
                 "How long until this status will automatically clear.": "多久後狀態自動清除。",
+                "Your status will be cleared after the selected time.": "在所選時間後，您的狀態將被清除。",
             "Visible to": "可見",
                 "Everyone": "任何人",
+                    "Limit status visibility to a single organization.": "將狀態可見範圍限制為單個組織。",
                     "Scope status visibility to a single organization.": "將狀態可視範圍擴大到單個組織。",
             "Filter emoji": "篩選表情符號",
                 "Search results": "篩選結果",
@@ -1525,6 +1529,7 @@ I18N["zh-TW"]["public"] = { // 公共區域翻譯
                         "Choose a repository to chat about.": "選擇以聊天",
                 "Remove topic": "移除主題",
                 "Add repositories, files, and spaces": "添加倉庫、文件和空間",
+                "Add files, and spaces": "添加文件和空間",
                 "Upload from computer": "上傳本機文件",
                 "Files and folders": "文件和文件夾",
                 "Spaces…": "空間…",
@@ -2416,6 +2421,7 @@ I18N["zh-TW"]["page-dashboard"] = { // 已登錄的首頁 - 儀表板（含組�
         [/Good evening, ([^ ]+)!/, "晚上好，$1！"],
         [/Switch dashboard: ([^ ]+)/, "切換儀表板：$1"],
         [/(.+)\#(\d+) · Opened by ([^ ]+) ·/, "$1#$2 · 打開者 $3"],
+        [/(\d+) characters remaining/, "還可輸入 $1 個字元"],
     ],
     "title": {
         "static": {
@@ -8719,6 +8725,9 @@ I18N["zh-TW"]["repository"] = { // 倉庫頁面 /<user-name>/<repo-name>/
 
                 // 提交欄 GitHub Action
                 "All checks have passed": "已通過所有檢查",
+                "View status": "查看狀態",
+                "What's new": "新變化",
+                "Switch to the classic experience": "切換到經典體驗",
 
 
                 // 關注 & 訂閱通知設置 下拉菜單
@@ -10375,8 +10384,10 @@ I18N["zh-TW"]["repository/issues"] = { // 倉庫 - 議題頁面
 
             "New label": "新建標籤",
                 "Label preview": "標籤預覽",
+                "Name": "名稱",
                 "Label name": "標籤名",
                 "Description": "描述",
+                "Optionally add a description": "可選新增描述",
                 "Description (optional)": "描述（可選）",
                 "Color": "顏色",
                     "Get a new color": "獲得新顏色",


### PR DESCRIPTION
## 变更背景
本 PR 在对齐上游 `gh-pages` 最新基线后，按“仅增量补充、不覆盖上游已有词条”的方式，补充缺失翻译。

## 本次新增词条（11 条）

1. `"What's happening"` -> `"发生了什么"`（zh-TW: `發生了什麼`）
2. `"Expiration"` -> `"有效期"`
3. `"Your status will be cleared after the selected time."` -> `"在所选时间后，您的状态将被清除。"`（zh-TW 已同步）
4. `"Limit status visibility to a single organization."` -> `"将状态可见范围限制为单个组织。"`（zh-TW 已同步）
5. `"Add files, and spaces"` -> `"添加文件和空间"`（zh-TW: `添加文件和空間`）
6. `"View status"` -> `"查看状态"`（zh-TW: `查看狀態`）
7. `"What's new"` -> `"新变化"`（zh-TW: `新變化`）
8. `"Switch to the classic experience"` -> `"切换到经典体验"`（zh-TW 已同步）
9. `"Name"` -> `"名称"`（补充于标签创建弹窗场景）
10. `"Optionally add a description"` -> `"可选添加描述"`（zh-TW: `可選新增描述`）
11. 正则：`/(\d+) characters remaining/` -> `"还可输入 $1 个字符"`（zh-TW: `還可輸入 $1 個字元`）

## 影响文件

- `locals.js`
- `locals(greasyfork).js`
- `locals_zh-TW.js`

## 主要覆盖场景

- 编辑状态弹窗
- Copilot 附件选择入口
- 仓库检查状态区域
- Label 创建弹窗
- Dashboard 字数剩余提示

## 说明

- 本 PR 为增量补词条，不移除、不重写上游既有词条。
- 简中与繁中词库结构保持一致。
