### PR TITLE
Potential fix for code scanning alert no. 7: Use of externally-controlled format string

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -408,7 +408,7 @@
             const reason = pageType === false
                 ? '路径未匹配任何页面规则'
                 : `词库中缺少 "${pageType}" 的翻译`;
-            console.warn(`[i18n] ${reason}`, {
+            console.warn('[i18n] %s', reason, {
                 url: window.location.href,
                 hostname,
                 pathname,


### PR DESCRIPTION
Potential fix for [https://github.com/maboloshi/github-chinese/security/code-scanning/7](https://github.com/maboloshi/github-chinese/security/code-scanning/7)

Use a constant format string for `console.warn` and pass dynamic/untrusted text as a `%s` argument, instead of embedding it into the first argument string.

Best fix in this snippet:
- In `main.user.js`, inside `detectPageType()` at the warning block (around line 411), change:
  - `console.warn(\`[i18n] ${reason}\`, { ... })`
  - to
  - `console.warn('[i18n] %s', reason, { ... })`

This preserves existing behavior (same message content and metadata object) while preventing attacker-controlled `%` sequences in `reason` from being treated as formatting directives in the first argument.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
