### PR TITLE
修复与补全翻译

### DIFF
--- a/locals.js
+++ b/locals.js
@@ -5870,6 +5870,11 @@ I18N["zh-CN"]["settings/repositories"] = { // 设置 - 仓库
             "Enabled by default": "默认启用",
             "Disabled by default": "默认禁用",
 
+            // 提交评论
+            "are enabled or disabled by default for repositories you own.": "默认对您拥有的仓库启用或禁用。",
+            "Individual repositories can override this default.": "各个仓库可以覆盖此默认设置。",
+            "Existing commit comments are not affected by this setting and will remain viewable, editable, and deletable.": "现有提交评论不会受到此设置影响，仍然可以查看、编辑和删除。",
+
     },
     "regexp": [ // 正则翻译
         [/(\d+) collaborators?/, "$1 位协作者"]

--- a/locals.js
+++ b/locals.js
@@ -4257,6 +4257,12 @@ I18N["zh-CN"]["settings/billing"] = { // 设置 - 账单和计划
         ...I18N["zh-CN"]["settings-menu"]["static"],
         ...I18N["zh-CN"]["orgs-settings-menu"]["static"], // 组织设置
 
+        // GitHub Copilot 正在转向 AI 积分提示
+        "GitHub Copilot is moving to AI credits":"GitHub Copilot 正在转向 AI 积分",
+        "Starting June 1, 2026 Copilot usage will be measured and billed in AI credits instead of Premium request units. AI credits give you more granular visibility into your usage across models and features. Preview how this change will affect your billing based on your recent usage.":"从2026年6月1日起，Copilot 的使用将以 AI 积分计量和计费，而不是高级请求单位。AI 积分可以让您更细致地了解不同模型和功能的使用情况。您可以预览此更改将如何根据您近期的使用情况影响您的计费。",
+        "Preview your usage":"预览你的使用情况",
+        "Read the blog post":"阅读博客",
+
         // 概况 https://github.com/settings/billing
             // 顶部提示
                 "Successfully updated billing information.": "成功更新支付信息。",


### PR DESCRIPTION
补全/修复 翻译:设置->仓库->提交评论
- 旧词库由于将句子太长，Github切分了词语导致匹配失败，将句子拆开放入词库以修复翻译

### 1.设置->仓库->提交评论

修复后:
<img width="1538" height="237" alt="image" src="https://github.com/user-attachments/assets/971520d9-6e7f-4b6c-b8c2-8e0761338f4f" />

修复前:
<img width="1598" height="557" alt="image" src="https://github.com/user-attachments/assets/5cc7adbd-e7b9-4e1a-9c95-4381361ebcf8" />

### 2.设置->账单->Github Copliot正在转向积分制度
翻译后:
<img width="1687" height="421" alt="image" src="https://github.com/user-attachments/assets/27b7cee9-45c8-4eae-90c1-377927290660" />

翻译前:
<img width="1622" height="437" alt="image" src="https://github.com/user-attachments/assets/2432efe7-8f5d-41e7-b1dc-3d653b1b9251" />
