### PR TITLE
修复 React 新版头部搜索框消失【临时性修复】

### DIFF
--- a/locals(greasyfork).js
+++ b/locals(greasyfork).js
@@ -105,6 +105,8 @@ I18N.conf = {
             '.cm-line',
         ],
         '*': [
+            'header.GlobalNav', // React 版全局导航
+            '#__primerPortalRoot__', // React 弹层挂载点
             'div.QueryBuilder-StyledInputContainer', // 顶部搜索栏 关键词
             '#qb-input-query span', // 搜索页面 搜索栏 关键词
 			'div.styled-input-content', // 筛选条
@@ -229,6 +231,8 @@ I18N.conf = {
             '.monaco-editor',
         ],
         '*': [
+            'header.GlobalNav', // React 版全局导航
+            '#__primerPortalRoot__', // React 弹层挂载点
             '.comment-body', '.js-preview-body',
             '.markdown-title',
             'span.ActionListItem-descriptionWrap',  // 顶部搜索栏 关键词

--- a/locals.js
+++ b/locals.js
@@ -105,6 +105,8 @@ I18N.conf = {
             '.cm-line',
         ],
         '*': [
+            'header.GlobalNav', // React 版全局导航
+            '#__primerPortalRoot__', // React 弹层挂载点
             'div.QueryBuilder-StyledInputContainer', // 顶部搜索栏 关键词
             '#qb-input-query span', // 搜索页面 搜索栏 关键词
 			'div.styled-input-content', // 筛选条
@@ -229,6 +231,8 @@ I18N.conf = {
             '.monaco-editor',
         ],
         '*': [
+            'header.GlobalNav', // React 版全局导航
+            '#__primerPortalRoot__', // React 弹层挂载点
             '.comment-body', '.js-preview-body',
             '.markdown-title',
             'span.ActionListItem-descriptionWrap',  // 顶部搜索栏 关键词

--- a/locals_zh-TW.js
+++ b/locals_zh-TW.js
@@ -105,6 +105,8 @@ I18N.conf = {
             '.cm-line',
         ],
         '*': [
+            'header.GlobalNav', // React 版全域導覽
+            '#__primerPortalRoot__', // React 彈層掛載點
             'div.QueryBuilder-StyledInputContainer', // 頂部搜尋欄 關鍵詞
             '#qb-input-query span', // 搜尋頁面 搜尋欄 關鍵詞
 			'div.styled-input-content', // 篩選條
@@ -229,6 +231,8 @@ I18N.conf = {
             '.monaco-editor',
         ],
         '*': [
+            'header.GlobalNav', // React 版全域導覽
+            '#__primerPortalRoot__', // React 彈層掛載點
             '.comment-body', '.js-preview-body',
             '.markdown-title',
             'span.ActionListItem-descriptionWrap',  // 頂部搜尋欄 關鍵詞

--- a/test/issue-702-regression.test.cjs
+++ b/test/issue-702-regression.test.cjs
@@ -1,0 +1,46 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const localeFiles = [
+    'locals.js',
+    'locals(greasyfork).js',
+    'locals_zh-TW.js',
+];
+
+const protectedReactSelectors = [
+    'header.GlobalNav',
+    '#__primerPortalRoot__',
+];
+
+function loadConfig(fileName) {
+    const filePath = path.join(__dirname, '..', fileName);
+    const context = vm.createContext({});
+
+    vm.runInContext(fs.readFileSync(filePath, 'utf8'), context, {
+        filename: filePath,
+    });
+
+    return context.I18N.conf;
+}
+
+for (const fileName of localeFiles) {
+    test(`${fileName} protects the React global navigation from translation`, () => {
+        const config = loadConfig(fileName);
+        const mutationSelectors = config.ignoreMutationSelectorPage['*'];
+        const traversalSelectors = config.ignoreSelectorPage['*'];
+
+        for (const selector of protectedReactSelectors) {
+            assert.ok(
+                mutationSelectors.includes(selector),
+                `${selector} must be ignored by MutationObserver translation`,
+            );
+            assert.ok(
+                traversalSelectors.includes(selector),
+                `${selector} must be ignored during the initial DOM traversal`,
+            );
+        }
+    });
+}


### PR DESCRIPTION
## 问题

GitHub 正在向登录用户灰度 React 版 `GlobalNav`。脚本首次遍历页面和处理后续 DOM mutation 时会直接改写该 React 管理区域中的文本或属性，使 React 内部状态与真实 DOM 不一致；点击搜索后组件重新渲染，搜索入口因此被卸载或隐藏。

Fixes #702

## 修改

- 在简体开发版、简体 GreasyFork 稳定版和繁体词库中同步保护 `header.GlobalNav` 与 `#__primerPortalRoot__`
- 同时加入 `ignoreSelectorPage` 与 `ignoreMutationSelectorPage`，覆盖首次遍历和后续 MutationObserver 两条翻译路径
- 使用稳定的语义 class / id，不依赖 `Search-module__*`、`styles-module__*` 等构建哈希类名
- 添加 Node 内置测试，确保三套词库始终保留这两层保护

## 影响与取舍

新版 React 全局导航及 Primer portal 内的弹层暂时保持英文，页面其他区域继续翻译。旧版 `qbsearch-input` 头部未被扩大忽略范围，原有行为不变。

相比在 `init()` 中运行时追加临时选择器，这次修复放在现有统一忽略配置中，避免逻辑分叉，也能覆盖简体、稳定版与繁体入口。

## 验证

- `node --test test/issue-702-regression.test.cjs`：3/3 通过
- `node --check`：三份词库、三份用户脚本与回归测试全部通过
- `git diff --check`：通过
- Chrome 最新版 + Tampermonkey 登录态人工回归：顶部搜索框可正常打开、输入和重复使用，不再消失
