### PR TITLE
feat: 配置 dependabot 自动更新 并 更新依赖

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3

--- a/.github/workflows/locals(greasyfork).js_update.yaml
+++ b/.github/workflows/locals(greasyfork).js_update.yaml
@@ -21,7 +21,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/main.user.js_version_update_and_sync_zh-TW.yaml
+++ b/.github/workflows/main.user.js_version_update_and_sync_zh-TW.yaml
@@ -24,7 +24,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -105,7 +105,7 @@ jobs:
     environment: github-pages
     steps:
       - name: Checkout files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.update_main.outputs.oid }}
 

--- a/.github/workflows/main.user.js_version_update_and_sync_zh-TW.yaml
+++ b/.github/workflows/main.user.js_version_update_and_sync_zh-TW.yaml
@@ -117,7 +117,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Cache apt packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /var/cache/apt/archives/*.deb

--- a/.github/workflows/remove_dup.yml
+++ b/.github/workflows/remove_dup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 拉取仓库
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 去重
         run: |

--- a/.github/workflows/update_contributors_images.yml
+++ b/.github/workflows/update_contributors_images.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Generate Contributors Images
-        uses: jaywcjlove/github-action-contributors@v1.3.5
+        uses: jaywcjlove/github-action-contributors@v2.1.0
         id: contributors
         with:
           filter-author: (action-assistant\[bot\]|renovate\[bot\]|renovate-bot|@github-actions-bot|dependabot\[bot\]|ImgBotApp|imgbot\[bot\])

--- a/.github/workflows/update_contributors_images.yml
+++ b/.github/workflows/update_contributors_images.yml
@@ -18,7 +18,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Contributors Images
         uses: jaywcjlove/github-action-contributors@v1.3.5


### PR DESCRIPTION
## 改动

### 依赖更新

- 更新 `actions/checkout` 至 `v6` 从 `v4`

- 更新 `jaywcjlove/github-action-contributors` 至 `v2.1.0` 从 `v1.3.5`

- 更新 `actions/cache` 至 `v5` 从 `v4`

### 配置自动更新

配置 dependabot.yml ，每周自动获取更新，如有更新则发起拉取请求（限制最大拉取请求数量：3）