### PR TITLE
fix: translate relative-time unit m as minutes not months

### DIFF
--- a/locals(greasyfork).js
+++ b/locals(greasyfork).js
@@ -2049,7 +2049,7 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
             }
         }],
         [/(\d+)(y|h|d|w|m)/, function (all, count, suffix) {
-            var suffixKey = {y: '年', h: '小时', d: '天', w: '周', m: '个月'};
+            var suffixKey = {y: '年', h: '小时', d: '天', w: '周', m: '分钟'};
 
             return count + ' ' + suffixKey[suffix] + '之前';
         }],

--- a/locals.js
+++ b/locals.js
@@ -2049,7 +2049,7 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
             }
         }],
         [/(\d+)(y|h|d|w|m)/, function (all, count, suffix) {
-            var suffixKey = {y: '年', h: '小时', d: '天', w: '周', m: '个月'};
+            var suffixKey = {y: '年', h: '小时', d: '天', w: '周', m: '分钟'};
 
             return count + ' ' + suffixKey[suffix] + '之前';
         }],

--- a/locals_zh-TW.js
+++ b/locals_zh-TW.js
@@ -2049,7 +2049,7 @@ I18N["zh-TW"]["public"] = { // 公共區域翻譯
             }
         }],
         [/(\d+)(y|h|d|w|m)/, function (all, count, suffix) {
-            var suffixKey = {y: '年', h: '小時', d: '天', w: '周', m: '個月'};
+            var suffixKey = {y: '年', h: '小時', d: '天', w: '周', m: '分鐘'};
 
             return count + ' ' + suffixKey[suffix] + '之前';
         }],


### PR DESCRIPTION
## What

Fix compact relative-time unit `m` being translated as months (月/个月) instead of minutes (分钟).

## Why

GitHub UI uses compact units like `5m` for **minutes**. Mapping `m` → 月 incorrectly shows times such as “1 个月之前” for a one-minute-old comment.

Closes #735

## Changes

- `locals.js`, `locals(greasyfork).js`, `locals_zh-TW.js`: update `suffixKey.m` from 个月/個月 → 分钟/分鐘

## Verification

- Confirmed regex `/(\d+)(y|h|d|w|m)/` is used for compact relative times
- `y/h/d/w` mappings unchanged
- `m` now maps to minutes to match GitHub’s compact minute unit