### PR TITLE
fix: 修正相对时间缩写 m 被误译为月 (#735)

### DIFF
--- a/locals(greasyfork).js
+++ b/locals(greasyfork).js
@@ -1932,6 +1932,17 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
             all = minute ? minute + '分' + second + '秒' : second + '秒';
             return (prefix ? all + '之内' : all);
         }],
+        /**
+         * 相对时间缩写（Intl.RelativeTimeFormat narrow）
+         * GitHub: s=秒, m=分钟, h=小时, d=天, w=周, mo=月, y=年
+         * 注意：mo 必须写在 m 前面，避免 1mo 被拆成 1m + o
+         * 修复 #735：原先 m 被误译为“个月”
+         */
+        [/^(\d+)(y|mo|h|d|w|m|s)(?: ago)?$/, function (all, count, suffix) {
+            var suffixKey = {y: '年', mo: '个月', h: '小时', d: '天', w: '周', m: '分钟', s: '秒'};
+
+            return count + ' ' + suffixKey[suffix] + '之前';
+        }],
 
         // 其他翻译
         [/to enable two-factor authentication as an additional security measure. Your activity on GitHub includes you in this requirement. You will need to enable two-factor authentication on your account before ([^ ]+), or be restricted from account actions./, "启用双因素身份验证（2FA）作为额外安全措施。您在 GitHub 上的活动让您接收到此要求。您将需要在 $1 前启用双因素身份验证，否则会被限制账户操作。"],
@@ -2048,8 +2059,8 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
                 return count + ' ' + unitKey[unit] + (prefix === 'in' ? '之内' : '之前');
             }
         }],
-        [/(\d+)(y|h|d|w|m)/, function (all, count, suffix) {
-            var suffixKey = {y: '年', h: '小时', d: '天', w: '周', m: '个月'};
+        [/(\d+)(y|mo|h|d|w|m|s)(?: ago)?/, function (all, count, suffix) {
+            var suffixKey = {y: '年', mo: '个月', h: '小时', d: '天', w: '周', m: '分钟', s: '秒'};
 
             return count + ' ' + suffixKey[suffix] + '之前';
         }],

--- a/locals.js
+++ b/locals.js
@@ -1932,6 +1932,17 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
             all = minute ? minute + '分' + second + '秒' : second + '秒';
             return (prefix ? all + '之内' : all);
         }],
+        /**
+         * 相对时间缩写（Intl.RelativeTimeFormat narrow）
+         * GitHub: s=秒, m=分钟, h=小时, d=天, w=周, mo=月, y=年
+         * 注意：mo 必须写在 m 前面，避免 1mo 被拆成 1m + o
+         * 修复 #735：原先 m 被误译为“个月”
+         */
+        [/^(\d+)(y|mo|h|d|w|m|s)(?: ago)?$/, function (all, count, suffix) {
+            var suffixKey = {y: '年', mo: '个月', h: '小时', d: '天', w: '周', m: '分钟', s: '秒'};
+
+            return count + ' ' + suffixKey[suffix] + '之前';
+        }],
 
         // 其他翻译
         [/to enable two-factor authentication as an additional security measure. Your activity on GitHub includes you in this requirement. You will need to enable two-factor authentication on your account before ([^ ]+), or be restricted from account actions./, "启用双因素身份验证（2FA）作为额外安全措施。您在 GitHub 上的活动让您接收到此要求。您将需要在 $1 前启用双因素身份验证，否则会被限制账户操作。"],
@@ -2048,8 +2059,14 @@ I18N["zh-CN"]["public"] = { // 公共区域翻译
                 return count + ' ' + unitKey[unit] + (prefix === 'in' ? '之内' : '之前');
             }
         }],
-        [/(\d+)(y|h|d|w|m)/, function (all, count, suffix) {
-            var suffixKey = {y: '年', h: '小时', d: '天', w: '周', m: '个月'};
+        /**
+         * 相对时间缩写（Intl.RelativeTimeFormat narrow）
+         * GitHub: s=秒, m=分钟, h=小时, d=天, w=周, mo=月, y=年
+         * 注意：mo 必须写在 m 前面，避免 1mo 被拆成 1m + o
+         * 修复 #735：原先 m 被误译为“个月”
+         */
+        [/(\d+)(y|mo|h|d|w|m|s)(?: ago)?/, function (all, count, suffix) {
+            var suffixKey = {y: '年', mo: '个月', h: '小时', d: '天', w: '周', m: '分钟', s: '秒'};
 
             return count + ' ' + suffixKey[suffix] + '之前';
         }],

--- a/locals_zh-TW.js
+++ b/locals_zh-TW.js
@@ -1932,6 +1932,17 @@ I18N["zh-TW"]["public"] = { // 公共區域翻譯
             all = minute ? minute + '分' + second + '秒' : second + '秒';
             return (prefix ? all + '之內' : all);
         }],
+        /**
+         * 相對時間縮寫（Intl.RelativeTimeFormat narrow）
+         * GitHub: s=秒, m=分鐘, h=小時, d=天, w=週, mo=月, y=年
+         * 注意：mo 必須寫在 m 前面，避免 1mo 被拆成 1m + o
+         * 修復 #735：原先 m 被誤譯為「個月」
+         */
+        [/^(\d+)(y|mo|h|d|w|m|s)(?: ago)?$/, function (all, count, suffix) {
+            var suffixKey = {y: '年', mo: '個月', h: '小時', d: '天', w: '周', m: '分鐘', s: '秒'};
+
+            return count + ' ' + suffixKey[suffix] + '之前';
+        }],
 
         // 其他翻譯
         [/to enable two-factor authentication as an additional security measure. Your activity on GitHub includes you in this requirement. You will need to enable two-factor authentication on your account before ([^ ]+), or be restricted from account actions./, "啟用雙因素身份驗證（2FA）作為額外安全措施。您在 GitHub 上的活動讓您接收到此要求。您將需要在 $1 前啟用雙因素身份驗證，否則會被限制帳戶操作。"],
@@ -2048,8 +2059,8 @@ I18N["zh-TW"]["public"] = { // 公共區域翻譯
                 return count + ' ' + unitKey[unit] + (prefix === 'in' ? '之內' : '之前');
             }
         }],
-        [/(\d+)(y|h|d|w|m)/, function (all, count, suffix) {
-            var suffixKey = {y: '年', h: '小時', d: '天', w: '周', m: '個月'};
+        [/(\d+)(y|mo|h|d|w|m|s)(?: ago)?/, function (all, count, suffix) {
+            var suffixKey = {y: '年', mo: '個月', h: '小時', d: '天', w: '周', m: '分鐘', s: '秒'};
 
             return count + ' ' + suffixKey[suffix] + '之前';
         }],

--- a/test/issue-735-relative-time-m.test.cjs
+++ b/test/issue-735-relative-time-m.test.cjs
@@ -1,0 +1,85 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+
+function loadLocale(fileName) {
+    const code = fs.readFileSync(path.join(root, fileName), 'utf8');
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(`${code}\nthis.I18N = I18N;`, ctx);
+    return ctx.I18N;
+}
+
+function translate(rules, text) {
+    for (const [pattern, replacement] of rules) {
+        const result = text.replace(pattern, replacement);
+        if (result !== text) return result;
+    }
+    return text;
+}
+
+const localeCases = [
+    {
+        file: 'locals.js',
+        lang: 'zh-CN',
+        cases: {
+            '1m': '1 分钟之前',
+            '1m ago': '1 分钟之前',
+            '30m': '30 分钟之前',
+            '1mo': '1 个月之前',
+            '1mo ago': '1 个月之前',
+            '12mo': '12 个月之前',
+            '2h': '2 小时之前',
+            '1d': '1 天之前',
+            '1w': '1 周之前',
+            '1y': '1 年之前',
+        },
+    },
+    {
+        file: 'locals(greasyfork).js',
+        lang: 'zh-CN',
+        cases: {
+            '1m': '1 分钟之前',
+            '1mo': '1 个月之前',
+            '2h': '2 小时之前',
+        },
+    },
+    {
+        file: 'locals_zh-TW.js',
+        lang: 'zh-TW',
+        cases: {
+            '1m': '1 分鐘之前',
+            '1mo': '1 個月之前',
+            '2h': '2 小時之前',
+            '1y': '1 年之前',
+        },
+    },
+];
+
+for (const { file, lang, cases } of localeCases) {
+    test(`issue #735: ${file} short relative-time units`, () => {
+        const pub = loadLocale(file)[lang].public;
+        assert.ok(pub, `missing ${lang}.public in ${file}`);
+
+        for (const [input, expected] of Object.entries(cases)) {
+            for (const which of ['regexp', 'time-regexp']) {
+                const got = translate(pub[which], input);
+                assert.equal(
+                    got,
+                    expected,
+                    `${file} ${which}: ${JSON.stringify(input)} => ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`
+                );
+            }
+        }
+
+        // Explicitly ensure minute is never translated as month.
+        assert.match(translate(pub.regexp, '1m'), /分钟|分鐘/);
+        assert.doesNotMatch(translate(pub.regexp, '1m'), /个月|個月/);
+        assert.match(translate(pub['time-regexp'], '1m'), /分钟|分鐘/);
+        assert.doesNotMatch(translate(pub['time-regexp'], '1m'), /个月|個月/);
+    });
+}


### PR DESCRIPTION
## What
修正 GitHub 相对时间缩写 `m` 被错误翻译为「月/个月」的问题。

## Why
GitHub 使用 `Intl.RelativeTimeFormat` 的 narrow 风格缩写：

| 缩写 | 含义 | 正确中文 |
|------|------|----------|
| `s` | second | 秒 |
| `m` | **minute** | **分钟** |
| `h` | hour | 小时 |
| `d` | day | 天 |
| `w` | week | 周 |
| `mo` | **month** | **个月** |
| `y` | year | 年 |

原先 `time-regexp` 中将 `m` 映射为「个月」，导致评论时间等处的 `1m` 被译成「1 个月之前」（见 #735）。

## Changes
- `locals.js` / `locals(greasyfork).js` / `locals_zh-TW.js`
  - 修复 `time-regexp` 缩写映射：`m` → 分钟，`mo` → 个月，并补充 `s`
  - 正则使用 `y|mo|h|d|w|m|s`（**`mo` 在 `m` 前**，避免 `1mo` 被拆成 `1m` + `o`）
  - 可选匹配 ` ago` 后缀
  - 同步将相同规则加入 `public.regexp`，使页面文本节点上的缩写时间也能正确翻译
- 新增回归测试 `test/issue-735-relative-time-m.test.cjs`

## Verification
```bash
node --test test/issue-735-relative-time-m.test.cjs
```
全部通过：`1m` → `1 分钟之前`，`1mo` → `1 个月之前`。

Closes #735