### PR TITLE
feat: 新增 VS Code 市场扩展目录（vscode-extension/）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Desktop.ini
 .idea
 
 main(local).js
+# VS Code extension package
+*.vsix

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ VS Code 集成浏览器  | [Integrated Browser Extensions][Integrated Browser Ex
 
 > [!IMPORTANT]
 > VS Code 必须以 `--enable-proposed-api boylett.integrated-browser-extensions` 启动，否则集成浏览器无法注入脚本。
+>
+> 扩展默认使用 [南大镜像源](https://mirror.nju.edu.cn/github-chinese/) 加载词库与主脚本，国内用户可直接访问。
 
 ## 🔧 本地调试
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ VS Code 集成浏览器  | [Integrated Browser Extensions][Integrated Browser Ex
 
 | 方式 | 说明 |
 |---|---|
-| VSIX **（推荐）** | 从[发行版](https://github.com/maboloshi/github-chinese/releases) 下载 `.vsix` → VS Code 右键 → 安装扩展 VSIX |
+| VSIX **（推荐）** | 从[发行版](https://github.com/maboloshi/github-chinese/releases)下载 `.vsix` → VS Code 右键 → 安装扩展 VSIX |
 | 源码安装 | `cd vscode-extension/ && npm install && npx @vscode/vsce package` |
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -115,6 +115,22 @@ VS Code 集成浏览器  | [Integrated Browser Extensions][Integrated Browser Ex
 
 </details>
 
+### VS Code 市场扩展
+
+> [GitHub 中文化](vscode-extension/) 是一款 VS Code 市场扩展，可自动完成上述配置。
+
+安装后会自动检测 [Integrated Browser Extensions][Integrated Browser Extensions] 并在 `userscripts` 目录下写入包装脚本。用户无需手动创建和粘贴。
+
+**安装方式**：
+
+| 方式 | 说明 |
+|---|---|
+| VSIX **（推荐）** | 从[发行版](https://github.com/maboloshi/github-chinese/releases) 下载 `.vsix` → VS Code 右键 → 安装扩展 VSIX |
+| 源码安装 | `cd vscode-extension/ && npm install && npx @vscode/vsce package` |
+
+> [!IMPORTANT]
+> VS Code 必须以 `--enable-proposed-api boylett.integrated-browser-extensions` 启动，否则集成浏览器无法注入脚本。
+
 ## 🔧 本地调试
 
 1. 安装 [Tampermonkey][Tampermonkey]，并启用 “允许访问文件网址”。

--- a/vscode-extension/.gitignore
+++ b/vscode-extension/.gitignore
@@ -1,0 +1,3 @@
+out/
+node_modules/
+*.vsix

--- a/vscode-extension/.vscode/launch.json
+++ b/vscode-extension/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--enable-proposed-api=boylett.integrated-browser-extensions"
+            ],
+            "outFiles": ["${workspaceFolder}/out/**/*.js"],
+            "preLaunchTask": "npm: watch"
+        }
+    ]
+}

--- a/vscode-extension/.vscode/tasks.json
+++ b/vscode-extension/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "isBackground": true,
+            "problemMatcher": "$tsc-watch"
+        }
+    ]
+}

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -1,0 +1,8 @@
+.vscode/**
+.vscode-test/**
+src/**
+.gitignore
+tsconfig.json
+node_modules
+**/*.ts
+**/*.map

--- a/vscode-extension/LICENSE
+++ b/vscode-extension/LICENSE
@@ -1,0 +1,15 @@
+GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+...
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,54 @@
+# GitHub 中文化 (VS Code 扩展)
+
+一键安装 GitHub 中文化脚本到 VS Code 集成浏览器。
+
+## 前提
+
+### 安装依赖扩展
+
+需要 [Integrated Browser Extensions](https://marketplace.visualstudio.com/items?itemName=boylett.integrated-browser-extensions)。
+
+> [!NOTE]
+> [从市场安装](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_find-and-install-an-extension)本扩展时会自动安装 Integrated Browser Extensions；[VSIX 安装](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_install-from-a-vsix)本扩展需手动安装依赖扩展。
+
+### 添加启动参数
+
+VS Code 必须带 `--enable-proposed-api boylett.integrated-browser-extensions` 参数启动。
+
+<details>
+<summary>带参数启动 VS Code 的方式</summary>
+
+- 打开[运行对话框](https://learn.microsoft.com/windows/advanced-settings/modern-run)，录入：
+  ```cmd
+  "%LOCALAPPDATA%\Programs\Microsoft VS Code\Code.exe" --enable-proposed-api boylett.integrated-browser-extensions
+  ```
+- 或修改[“开始”菜单](https://www.microsoft.com/zh-cn/windows/tips/start-menu)的 VS Code 快捷方式，在 `目标` 字段末尾追加 [COMMAND_LINE_ARGUMENTS](https://learn.microsoft.com/openspecs/windows_protocols/ms-shllink/17b69472-0f34-4bcf-b290-eccdb8de224b)：
+  ```cmd
+   --enable-proposed-api boylett.integrated-browser-extensions
+  ```
+  然后从“开始”菜单启动
+
+</details>
+
+## 从本仓库源码构建
+
+1. [克隆仓库](https://docs.github.com/zh/repositories/creating-and-managing-repositories/cloning-a-repository)
+1. [在 VS Code 中打开该文件夹](https://code.visualstudio.com/docs/editor/workspaces#_folder-projects)
+1. [打开终端](https://code.visualstudio.com/docs/terminal/getting-started#_run-your-first-command-in-the-terminal)，执行：
+   ```powershell
+   cd vscode-extension
+   npm install
+   npx @vscode/vsce package
+   ```
+1. [从 VSIX 安装](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_install-from-a-vsix)
+
+> [!TIP]
+> 推荐从[发行版](https://github.com/maboloshi/github-chinese/releases)直接下载 `.vsix`（如有）。
+
+## 调试
+
+[打开扩展开发宿主窗口](https://code.visualstudio.com/api/get-started/your-first-extension#debugging-the-extension)。
+
+## 许可
+
+[GPL-3.0](LICENSE)

--- a/vscode-extension/main(vscode).user.js
+++ b/vscode-extension/main(vscode).user.js
@@ -1,0 +1,38 @@
+// ==UserScript==
+// @name         GitHub 中文化插件 (VS Code)
+// @namespace    https://github.com/maboloshi/github-chinese
+// @description  专为 VS Code 集成浏览器 + Integrated Browser Extensions 优化。
+//                ⚠️ 注意：Integrated Browser Extensions 的 GitHub 源码仓库已被删除（404），
+//                市场列表仍存在但不再维护。此脚本供已安装用户参考。
+//                📌 关注 https://github.com/maboloshi/github-chinese/issues/747#issuecomment-5046504139 获取最新进展。
+// @copyright    2021, 沙漠之子 (https://maboloshi.github.io/Blog)
+// @icon         https://github.githubassets.com/pinned-octocat.svg
+// @version      1.0.0
+// @author       沙漠之子
+// @license      GPL-3.0
+// @match        https://github.com/*
+// @match        https://skills.github.com/*
+// @match        https://gist.github.com/*
+// @match        https://education.github.com/*
+// @match        https://www.githubstatus.com/*
+// @run-at       document-start
+// @grant        GM_addStyle
+// @grant        GM_xmlhttpRequest
+// @grant        GM_getValue
+// @grant        GM_setValue
+// @grant        GM_registerMenuCommand
+// @grant        GM_unregisterMenuCommand
+// @grant        GM_notification
+// @connect      fanyi.iflyrec.com
+// @require      https://mirror.nju.edu.cn/github-chinese/locals.js
+// @require      https://mirror.nju.edu.cn/github-chinese/main.user.js
+// @supportURL   https://github.com/maboloshi/github-chinese/issues/747#issuecomment-5046504139
+// ==/UserScript==
+
+// 此文件为 VS Code Integrated Browser Extensions 的轻量包装脚本。
+// 通过 @require 从南大镜像远程加载 locals.js（词库）和 main.user.js（主逻辑）。
+// 如果 raw.githubusercontent.com 不可达，可使用南大镜像源 [main(nju.edu).user.js]。
+
+(function () {
+    'use strict';
+})();

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "github-chinese",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "github-chinese",
+      "version": "1.0.0",
+      "license": "GPL-3.0",
+      "devDependencies": {
+        "@types/vscode": "^1.116.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "vscode": "^1.116.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -55,16 +55,6 @@
         "command": "github-chinese.status",
         "title": "GitHub 中文化: 检查脚本状态"
       }
-    ],
-    "configuration": {
-      "title": "GitHub 中文化",
-      "properties": {
-        "github-chinese.mirrorUrl": {
-          "type": "string",
-          "default": "https://mirror.nju.edu.cn/github-chinese",
-          "description": "词库和主脚本的镜像地址（国内用户默认使用南大镜像）"
-        }
-      }
-    }
+    ]
   }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "github-chinese",
+  "displayName": "GitHub 中文化",
+  "description": "一键安装 GitHub 中文化脚本到 VS Code 集成浏览器",
+  "version": "1.0.0",
+  "author": "PtJade-Ceramic",
+  "publisher": "PtJade-Ceramic",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/maboloshi/github-chinese"
+  },
+  "engines":  {
+    "vscode": "^1.116.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    "github",
+    "chinese",
+    "translation",
+    "i18n",
+    "github-chinese"
+  ],
+  "extensionDependencies": [
+    "boylett.integrated-browser-extensions"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./out/extension.js",
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "lint": "tsc --noEmit",
+    "package": "vsce package"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.116.0",
+    "typescript": "^5.5.0"
+  },
+  "contributes": {
+    "commands": [
+      {
+        "command": "github-chinese.install",
+        "title": "GitHub 中文化: 安装/更新集成浏览器脚本"
+      },
+      {
+        "command": "github-chinese.uninstall",
+        "title": "GitHub 中文化: 卸载集成浏览器脚本"
+      },
+      {
+        "command": "github-chinese.status",
+        "title": "GitHub 中文化: 检查脚本状态"
+      }
+    ],
+    "configuration": {
+      "title": "GitHub 中文化",
+      "properties": {
+        "github-chinese.mirrorUrl": {
+          "type": "string",
+          "default": "https://mirror.nju.edu.cn/github-chinese",
+          "description": "词库和主脚本的镜像地址（国内用户默认使用南大镜像）"
+        }
+      }
+    }
+  }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,177 @@
+import * as vscode from 'vscode';
+
+const USERSCRIPT_NAME = 'github-chinese.user.js';
+
+let _ctx: vscode.ExtensionContext;
+
+// ─── 检测集成浏览器扩展 ───────────────────────────────────────
+
+function isIntegratedBrowserInstalled(): boolean {
+    return vscode.extensions.getExtension('boylett.integrated-browser-extensions') !== undefined;
+}
+
+// ─── 核心操作 ──────────────────────────────────────────────────
+
+async function installScript(): Promise<boolean> {
+    if (!isIntegratedBrowserInstalled()) {
+        if ((await vscode.window.showErrorMessage('未检测到 Integrated Browser Extensions，请先安装该扩展。', '打开扩展市场')) === '打开扩展市场') {
+            vscode.commands.executeCommand('workbench.extensions.search', 'boylett.integrated-browser-extensions');
+        }
+        return false;
+    }
+
+    const mirrorUrl = vscode.workspace.getConfiguration('github-chinese').get<string>('mirrorUrl', 'https://mirror.nju.edu.cn/github-chinese')!;
+    const userscriptsDir = vscode.Uri.joinPath(_ctx.globalStorageUri, '../boylett.integrated-browser-extensions/userscripts');
+    try { await vscode.workspace.fs.stat(userscriptsDir); } catch { await vscode.workspace.fs.createDirectory(userscriptsDir); }
+
+    await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(userscriptsDir, USERSCRIPT_NAME), new TextEncoder().encode(
+`// ==UserScript==
+// @name         GitHub 中文化插件 (VS Code)
+// @namespace    https://github.com/maboloshi/github-chinese
+// @description  通过 VS Code 集成浏览器自动注入—GitHub 界面全面中文化
+// @version      1.0.0
+// @author       沙漠之子
+// @license      GPL-3.0
+// @match        https://github.com/*
+// @match        https://skills.github.com/*
+// @match        https://gist.github.com/*
+// @match        https://education.github.com/*
+// @match        https://www.githubstatus.com/*
+// @run-at       document-start
+// @grant        GM_addStyle
+// @grant        GM_xmlhttpRequest
+// @grant        GM_getValue
+// @grant        GM_setValue
+// @grant        GM_registerMenuCommand
+// @grant        GM_unregisterMenuCommand
+// @grant        GM_notification
+// @connect      fanyi.iflyrec.com
+// @require      ${mirrorUrl}/locals.js
+// @require      ${mirrorUrl}/main.user.js
+// ==/UserScript==
+
+(function () {
+    "use strict";
+})();
+`));
+
+    vscode.window.showInformationMessage('✅ GitHub 中文化脚本已安装到集成浏览器！\n请确保 VS Code 以 --enable-proposed-api boylett.integrated-browser-extensions 启动。');
+    await refreshStatus();
+    return true;
+}
+
+async function checkStatus(): Promise<{ installed: boolean; ibVersion: string; scriptPath?: string }> {
+    const ext = vscode.extensions.getExtension('boylett.integrated-browser-extensions');
+    const ibVersion = ext ? ext.packageJSON.version || '?' : '未安装';
+
+    const p = vscode.Uri.joinPath(_ctx.globalStorageUri, '../boylett.integrated-browser-extensions/userscripts', USERSCRIPT_NAME);
+    let installed = false;
+    try { await vscode.workspace.fs.stat(p); installed = true; } catch { installed = false; }
+
+    return { installed, ibVersion, scriptPath: p.fsPath };
+}
+
+// ─── 状态栏 ────────────────────────────────────────────────────
+
+let statusBarItem: vscode.StatusBarItem;
+
+function updateStatusBar(installed: boolean): void {
+    if (!statusBarItem) {
+        return;
+    }
+    if (installed) {
+        statusBarItem.text = '$(check) GitHub 中文化';
+        statusBarItem.tooltip = 'GitHub 中文化脚本已安装';
+        statusBarItem.backgroundColor = undefined;
+    } else {
+        statusBarItem.text = '$(circle-slash) GitHub 中文化';
+        statusBarItem.tooltip = '点击安装 GitHub 中文化脚本';
+        statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+    }
+    statusBarItem.show();
+}
+
+async function refreshStatus(): Promise<void> {
+    updateStatusBar((await checkStatus()).installed);
+}
+
+// ─── 激活 ──────────────────────────────────────────────────────
+
+export async function activate(context: vscode.ExtensionContext) {
+    _ctx = context;
+    console.log('[github-chinese] 扩展已激活');
+
+    // 状态栏
+    statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+    statusBarItem.command = 'github-chinese.status';
+    _ctx.subscriptions.push(statusBarItem);
+
+    // 初始状态
+    const status = await checkStatus();
+    updateStatusBar(status.installed);
+
+    // 注册命令
+    _ctx.subscriptions.push(
+        vscode.commands.registerCommand('github-chinese.install', () =>
+            vscode.window.withProgress(
+                { location: vscode.ProgressLocation.Notification, title: '安装 GitHub 中文化脚本…' },
+                () => installScript()
+            )
+        ),
+        vscode.commands.registerCommand('github-chinese.uninstall', async () => {
+            try {
+                await vscode.workspace.fs.stat(vscode.Uri.joinPath(_ctx.globalStorageUri, '../boylett.integrated-browser-extensions/userscripts', USERSCRIPT_NAME));
+                await vscode.workspace.fs.delete(vscode.Uri.joinPath(_ctx.globalStorageUri, '../boylett.integrated-browser-extensions/userscripts', USERSCRIPT_NAME));
+                vscode.window.showInformationMessage('🗑️ GitHub 中文化脚本已卸载。');
+            } catch {
+                vscode.window.showInformationMessage('⚠️ 未找到已安装的 GitHub 中文化脚本。');
+            }
+            await refreshStatus();
+        }),
+        vscode.commands.registerCommand('github-chinese.status', async () => {
+            const s = await checkStatus();
+            vscode.window.createWebviewPanel('github-chinese-status', 'GitHub 中文化 — 状态', vscode.ViewColumn.Active, { enableScripts: false }).webview.html = `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<style>
+body { font-family: var(--vscode-font-family); padding: 20px; }
+h1 { font-size: 1.3em; }
+.ok { color: var(--vscode-testing-iconPassed); }
+.fail { color: var(--vscode-testing-iconFailed); }
+code { background: var(--vscode-textCodeBlock-background); padding: 1px 4px; border-radius: 3px; }
+</style>
+</head>
+<body>
+<h1>📊 GitHub 中文化 — 状态</h1>
+<hr>
+<p class="${s.ibVersion ? 'ok' : 'fail'}">
+  <strong>Integrated Browser Extensions</strong>:
+  ${s.ibVersion ? '✅ 已安装 (' + s.ibVersion + ')' : '❌ 未安装'}
+</p>
+<p class="${s.installed ? 'ok' : 'fail'}">
+  <strong>用户脚本</strong>:
+  ${s.installed ? '✅ 已安装' : '❌ 未安装'}
+</p>
+<p><strong>脚本路径</strong>: <code>${s.scriptPath}</code></p>
+<blockquote>⚠️ 确保以 <code>--enable-proposed-api boylett.integrated-browser-extensions</code> 启动 VS Code</blockquote>
+<hr>
+<p><button onclick="window.location.href='command:github-chinese.install'">🔄 重新安装</button>
+<button onclick="window.location.href='command:github-chinese.uninstall'">🗑️ 卸载</button></p>
+</body>
+</html>`;
+    }));
+
+    // 启动后自动安装一次（仅当未安装时）
+    if (!status.installed) {
+        setTimeout(() => {
+            if (isIntegratedBrowserInstalled()) {
+                installScript();
+            }
+        }, 5000);
+    }
+}
+
+export function deactivate() {
+    // 清理
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -20,40 +20,13 @@ async function installScript(): Promise<boolean> {
         return false;
     }
 
-    const mirrorUrl = vscode.workspace.getConfiguration('github-chinese').get<string>('mirrorUrl', 'https://mirror.nju.edu.cn/github-chinese')!;
     const userscriptsDir = vscode.Uri.joinPath(_ctx.globalStorageUri, '../boylett.integrated-browser-extensions/userscripts');
     try { await vscode.workspace.fs.stat(userscriptsDir); } catch { await vscode.workspace.fs.createDirectory(userscriptsDir); }
 
-    await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(userscriptsDir, USERSCRIPT_NAME), new TextEncoder().encode(
-`// ==UserScript==
-// @name         GitHub 中文化插件 (VS Code)
-// @namespace    https://github.com/maboloshi/github-chinese
-// @description  通过 VS Code 集成浏览器自动注入—GitHub 界面全面中文化
-// @version      1.0.0
-// @author       沙漠之子
-// @license      GPL-3.0
-// @match        https://github.com/*
-// @match        https://skills.github.com/*
-// @match        https://gist.github.com/*
-// @match        https://education.github.com/*
-// @match        https://www.githubstatus.com/*
-// @run-at       document-start
-// @grant        GM_addStyle
-// @grant        GM_xmlhttpRequest
-// @grant        GM_getValue
-// @grant        GM_setValue
-// @grant        GM_registerMenuCommand
-// @grant        GM_unregisterMenuCommand
-// @grant        GM_notification
-// @connect      fanyi.iflyrec.com
-// @require      ${mirrorUrl}/locals.js
-// @require      ${mirrorUrl}/main.user.js
-// ==/UserScript==
-
-(function () {
-    "use strict";
-})();
-`));
+    await vscode.workspace.fs.writeFile(
+        vscode.Uri.joinPath(userscriptsDir, USERSCRIPT_NAME),
+        await vscode.workspace.fs.readFile(vscode.Uri.joinPath(_ctx.extensionUri, 'main(vscode).user.js'))
+    );
 
     vscode.window.showInformationMessage('✅ GitHub 中文化脚本已安装到集成浏览器！\n请确保 VS Code 以 --enable-proposed-api boylett.integrated-browser-extensions 启动。');
     await refreshStatus();

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
### 新增内容

- `vscode-extension/` 目录：可上架 VS Code 市场的扩展
- 自动检测 Integrated Browser Extensions 并写入用户脚本
- 提供安装/卸载/查看状态命令
- 不依赖任何提议 API，可直接发布到市场
- 硬链接共享主仓库的 `main(vscode).user.js`，修改一处两处生效

### 发布到 VS Code 市场

1. 访问 https://marketplace.visualstudio.com/manage 创建发布者
2. 运行以下命令打包并发布：

```bash
cd vscode-extension
npm install
npx @vscode/vsce package
npx @vscode/vsce publish
```

### 附加到 GitHub 发行版

如果不打算上架市场，可将打包的 `.vsix` 文件直接附加到 Release：

```bash
cd vscode-extension
npm install
npx @vscode/vsce package
# 输出的 github-chinese-*.vsix 附加到 Release 即可
```

由 @PtJade-Ceramic 贡献。