### PR TITLE
docs: 精简 README, 转向扩展自述文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - [🌐 兼容环境](#-兼容环境)
 - [💻 安装指南](#-安装指南)
     - [浏览器（Tampermonkey）](#浏览器tampermonkey)
-    - [VS Code 集成浏览器](#vs-code-集成浏览器)
+    - [VS Code 市场扩展](#vs-code-市场扩展)
 - [🔧 本地调试](#-本地调试)
 - [🔄 更新日志](#-更新日志)
 - [📌 待办事项](#-待办事项)
@@ -80,7 +80,7 @@ VS Code 集成浏览器  | [Integrated Browser Extensions][Integrated Browser Ex
     - [GreasyFork 源【稳定版】][main(greasyfork).user.js]
 1. 刷新页面后，插件即可生效
 1. 必要时，重启浏览器
-1. 对于 **VS Code 集成浏览器**，请参考下方 [VS Code 集成浏览器](#vs-code-集成浏览器) 小节
+1. 对于 **VS Code 集成浏览器**，请参考[本项目 VS Code 扩展的自述文件](vscode-extension/README.md)
 
 [^1]: [Chrome 切换到 Manifest V3后，使用问题](https://github.com/maboloshi/github-chinese/issues/234)
 
@@ -88,32 +88,6 @@ VS Code 集成浏览器  | [Integrated Browser Extensions][Integrated Browser Ex
 > **版本说明**：
 > - 🚀 开发版：实时更新，每周五自动更新词库
 > - 🛡️ 稳定版：每周一同步开发版词库，更稳定
-
-### VS Code 集成浏览器
-
-> [!WARNING]
-> [Integrated Browser Extensions][Integrated Browser Extensions] 的 GitHub 源码仓库已被作者删除（404），市场列表仍存在，但扩展不再维护。以下方法供参考。
-
-<details>
-<summary>历史配置方法（扩展的源码仓库已删除）</summary>
-
-适用于 VS Code 集成浏览器（[1.116+](https://code.visualstudio.com/docs/supporting/faq#_how-do-i-find-my-current-vs-code-version)），通过 Integrated Browser Extensions 运行。
-
-1. 安装 [Integrated Browser Extensions][Integrated Browser Extensions]
-1. 打开 **Browser Scripts** 面板（活动栏），点击 **+ New Userscript**
-1. 粘贴 [main(vscode).user.js][main(vscode).user.js] 内容并保存
-1. **关键**：该扩展依赖 VS Code `browser` 提案 API，需通过以下方式之一启用：
-    - **Win+R** 粘贴运行：
-      ```
-      "%LOCALAPPDATA%\Programs\Microsoft VS Code\Code.exe" --enable-proposed-api boylett.integrated-browser-extensions
-      ```
-    - 或修改开始菜单快捷方式的`目标`字段，在 `Code.exe` 后追加 ` --enable-proposed-api boylett.integrated-browser-extensions`
-1. 打开[集成浏览器][vscode-integrated-browser] → 进入 `github.com`
-
-> [!NOTE]
-> 如果 `raw.githubusercontent.com` 不可达，`main(vscode).user.js` 已默认使用南大镜像源。
-
-</details>
 
 ### VS Code 市场扩展
 
@@ -483,7 +457,6 @@ GitHub 的 ajax 载入方式逐步从 [defunkt/jquery-pjax](https://github.com/d
 [main.user.js]: https://github.com/maboloshi/github-chinese/raw/gh-pages/main.user.js "GitHub 中文化插件 - GitHub 源"
 [main(nju.edu).user.js]:https://mirror.nju.edu.cn/github-chinese/main(nju.edu).user.js "GitHub 中文化插件 - 南大镜像源"
 [main(greasyfork).user.js]: https://greasyfork.org/scripts/435208-github-%E4%B8%AD%E6%96%87%E5%8C%96%E6%8F%92%E4%BB%B6/code/GitHub%20%E4%B8%AD%E6%96%87%E5%8C%96%E6%8F%92%E4%BB%B6.user.js "GitHub 中文化插件 - GreasyFork 源"
-[main(vscode).user.js]: main(vscode).user.js "GitHub 中文化插件 - VS Code 集成浏览器"
 [update-contributors-images]: https://github.com/maboloshi/github-chinese/blob/gh-pages/.github/workflows/update_contributors_images.yml
 [Integrated Browser Extensions]: https://marketplace.visualstudio.com/items?itemName=boylett.integrated-browser-extensions "Integrated Browser Extensions"
-[vscode-integrated-browser]: https://code.visualstudio.com/docs/debugtest/integrated-browser "VS Code 集成浏览器"
+

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ VS Code 集成浏览器  | [Integrated Browser Extensions][Integrated Browser Ex
     - [GreasyFork 源【稳定版】][main(greasyfork).user.js]
 1. 刷新页面后，插件即可生效
 1. 必要时，重启浏览器
-1. 对于 **VS Code 集成浏览器**，请参考[本项目 VS Code 扩展的自述文件](vscode-extension/README.md)
 
 [^1]: [Chrome 切换到 Manifest V3后，使用问题](https://github.com/maboloshi/github-chinese/issues/234)
 
@@ -89,23 +88,9 @@ VS Code 集成浏览器  | [Integrated Browser Extensions][Integrated Browser Ex
 > - 🚀 开发版：实时更新，每周五自动更新词库
 > - 🛡️ 稳定版：每周一同步开发版词库，更稳定
 
-### VS Code 市场扩展
+### VS Code 集成浏览器（Integrated Browser Extensions）
 
-> [GitHub 中文化](vscode-extension/) 是一款 VS Code 市场扩展，可自动完成上述配置。
-
-安装后会自动检测 [Integrated Browser Extensions][Integrated Browser Extensions] 并在 `userscripts` 目录下写入包装脚本。用户无需手动创建和粘贴。
-
-**安装方式**：
-
-| 方式 | 说明 |
-|---|---|
-| VSIX **（推荐）** | 从[发行版](https://github.com/maboloshi/github-chinese/releases)下载 `.vsix` → VS Code 右键 → 安装扩展 VSIX |
-| 源码安装 | `cd vscode-extension/ && npm install && npx @vscode/vsce package` |
-
-> [!IMPORTANT]
-> VS Code 必须以 `--enable-proposed-api boylett.integrated-browser-extensions` 启动，否则集成浏览器无法注入脚本。
->
-> 扩展默认使用 [南大镜像源](https://mirror.nju.edu.cn/github-chinese/) 加载词库与主脚本，国内用户可直接访问。
+请参考[扩展的自述文件](vscode-extension/README.md)。
 
 ## 🔧 本地调试
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -10,8 +10,11 @@
 
 需要 [Integrated Browser Extensions](https://marketplace.visualstudio.com/items?itemName=boylett.integrated-browser-extensions)。
 
+> [!WARNING]
+> 该依赖扩展的 GitHub 源码仓库已被作者删除（404），市场列表仍存在但扩展不再维护。功能在当前版本中正常可用，但未来可能因 VS Code 更新而失效。
+
 > [!NOTE]
-> [从市场安装](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_find-and-install-an-extension)本扩展时会自动安装 Integrated Browser Extensions；[VSIX 安装](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_install-from-a-vsix)本扩展需手动安装依赖扩展。
+> [从市场安装](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_find-and-install-an-extension)本扩展时会自动安装 Integrated Browser Extensions；[VSIX 安装](#从本仓库源码构建)本扩展需手动安装依赖扩展。
 
 ### 添加启动参数
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,5 +1,7 @@
 # GitHub 中文化 (VS Code 扩展)
 
+[![license GPL-3.0](https://img.shields.io/github/license/maboloshi/github-chinese?style=flat-square&label=License)](https://opensource.org/licenses/GPL-3.0)
+
 一键安装 GitHub 中文化脚本到 VS Code 集成浏览器。
 
 ## 前提
@@ -48,7 +50,3 @@ VS Code 必须带 `--enable-proposed-api boylett.integrated-browser-extensions` 
 ## 调试
 
 [打开扩展开发宿主窗口](https://code.visualstudio.com/api/get-started/your-first-extension#debugging-the-extension)。
-
-## 许可
-
-[GPL-3.0](LICENSE)

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -14,7 +14,7 @@
 > 该依赖扩展的 GitHub 源码仓库已被作者删除（404），市场列表仍存在但扩展不再维护。功能在当前版本中正常可用，但未来可能因 VS Code 更新而失效。
 
 > [!NOTE]
-> [从市场安装](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_find-and-install-an-extension)本扩展时会自动安装 Integrated Browser Extensions；[VSIX 安装](#从本仓库源码构建)本扩展需手动安装依赖扩展。
+> 本扩展尚未上架 [VS Code 市场](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_find-and-install-an-extension)，需通过[源码构建](#从本仓库源码构建)或下载 VSIX 安装。上架后从市场安装时会自动安装 Integrated Browser Extensions。
 
 ### 添加启动参数
 


### PR DESCRIPTION
### 主自述文件

- VS Code 跳转改为指向 `vscode-extension/README.md`（https://github.com/maboloshi/github-chinese/pull/750#issuecomment-5059519632）
- 移除手动配置小节
- 清理未引用链接

### 扩展自述文件

- 添加许可证徽章
- 说明依赖扩展已停止维护
- 说明本扩展尚未上架
- 补充 VSIX 安装、启动参数等指引