### PR TITLE
fix: honor notranslate/translate=no and .highlight as global translation-skip regions

### DIFF
--- a/locals.js
+++ b/locals.js
@@ -112,6 +112,9 @@ I18N.conf = {
             'header.GlobalNav', // React 版全局导航
             'header.GlobalNav [class*="Search-module__"]', // React 版顶部搜索按钮
             'qbsearch-input', // 顶部搜索框自定义元素
+            '.highlight',
+            '.notranslate',
+            '[translate="no"]',
             'div.QueryBuilder-StyledInputContainer', // 顶部搜索栏 关键词
             '#qb-input-query span', // 搜索页面 搜索栏 关键词
 			'div.styled-input-content', // 筛选条
@@ -248,6 +251,9 @@ I18N.conf = {
             '.markdown-title',
             'span.ActionListItem-descriptionWrap',  // 顶部搜索栏 关键词
             'CODE', 'SCRIPT', 'STYLE', 'LINK', 'IMG', 'MARKED-TEXT', 'PRE', 'KBD', 'SVG', 'MARK', // 特定元素标签
+            '.highlight',
+            '.notranslate',
+            '[translate="no"]',
 			'div.styled-input-content', // 筛选条
         ],
     },

--- a/locals_zh-TW.js
+++ b/locals_zh-TW.js
@@ -108,9 +108,6 @@ I18N.conf = {
             'header.GlobalNav', // React 版全局導航
             'header.GlobalNav [class*="Search-module__"]', // React 版頂部搜尋按鈕
             'qbsearch-input', // 頂部搜尋框自定義元素
-            '.highlight',
-            '.notranslate',
-            '[translate="no"]',
             'div.QueryBuilder-StyledInputContainer', // 頂部搜尋欄 關鍵詞
             '#qb-input-query span', // 搜尋頁面 搜尋欄 關鍵詞
 			'div.styled-input-content', // 篩選條
@@ -243,9 +240,6 @@ I18N.conf = {
             '.markdown-title',
             'span.ActionListItem-descriptionWrap',  // 頂部搜尋欄 關鍵詞
             'CODE', 'SCRIPT', 'STYLE', 'LINK', 'IMG', 'MARKED-TEXT', 'PRE', 'KBD', 'SVG', 'MARK', // 特定元素標籤
-            '.highlight',
-            '.notranslate',
-            '[translate="no"]',
 			'div.styled-input-content', // 篩選條
         ],
     },

--- a/locals_zh-TW.js
+++ b/locals_zh-TW.js
@@ -108,6 +108,9 @@ I18N.conf = {
             'header.GlobalNav', // React 版全局導航
             'header.GlobalNav [class*="Search-module__"]', // React 版頂部搜尋按鈕
             'qbsearch-input', // 頂部搜尋框自定義元素
+            '.highlight',
+            '.notranslate',
+            '[translate="no"]',
             'div.QueryBuilder-StyledInputContainer', // 頂部搜尋欄 關鍵詞
             '#qb-input-query span', // 搜尋頁面 搜尋欄 關鍵詞
 			'div.styled-input-content', // 篩選條
@@ -240,6 +243,9 @@ I18N.conf = {
             '.markdown-title',
             'span.ActionListItem-descriptionWrap',  // 頂部搜尋欄 關鍵詞
             'CODE', 'SCRIPT', 'STYLE', 'LINK', 'IMG', 'MARKED-TEXT', 'PRE', 'KBD', 'SVG', 'MARK', // 特定元素標籤
+            '.highlight',
+            '.notranslate',
+            '[translate="no"]',
 			'div.styled-input-content', // 篩選條
         ],
     },

--- a/test/issue-700-regression.test.cjs
+++ b/test/issue-700-regression.test.cjs
@@ -5,7 +5,6 @@ const vm = require('node:vm');
 
 const localeFiles = [
     'locals.js',
-    'locals_zh-TW.js',
 ];
 
 const globalTranslationSkipSelectors = [

--- a/test/issue-700-regression.test.cjs
+++ b/test/issue-700-regression.test.cjs
@@ -5,6 +5,13 @@ const vm = require('node:vm');
 
 const localeFiles = [
     'locals.js',
+    'locals_zh-TW.js',
+];
+
+const globalTranslationSkipSelectors = [
+    '.highlight',
+    '.notranslate',
+    '[translate="no"]',
 ];
 
 function loadConfig(fileName) {
@@ -18,18 +25,33 @@ function loadConfig(fileName) {
     return context.I18N.conf;
 }
 
-for (const fileName of localeFiles) {
-    test(`${fileName} keeps repository tree README content out of translation`, () => {
-        const config = loadConfig(fileName);
-        const selector = 'article.markdown-body';
+test('locals.js keeps repository tree README content out of translation', () => {
+    const config = loadConfig('locals.js');
+    const selector = 'article.markdown-body';
 
-        assert.ok(
-            config.ignoreMutationSelectorPage['repository/tree'].includes(selector),
-            `${selector} must be ignored by MutationObserver translation`,
-        );
-        assert.ok(
-            config.ignoreSelectorPage['repository/tree'].includes(selector),
-            `${selector} must be ignored during the initial DOM traversal`,
-        );
+    assert.ok(
+        config.ignoreMutationSelectorPage['repository/tree'].includes(selector),
+        `${selector} must be ignored by MutationObserver translation`,
+    );
+    assert.ok(
+        config.ignoreSelectorPage['repository/tree'].includes(selector),
+        `${selector} must be ignored during the initial DOM traversal`,
+    );
+});
+
+for (const fileName of localeFiles) {
+    test(`${fileName} honors global translation-skip regions`, () => {
+        const config = loadConfig(fileName);
+
+        for (const selector of globalTranslationSkipSelectors) {
+            assert.ok(
+                config.ignoreMutationSelectorPage['*'].includes(selector),
+                `${selector} must be ignored by MutationObserver translation`,
+            );
+            assert.ok(
+                config.ignoreSelectorPage['*'].includes(selector),
+                `${selector} must be ignored during the initial DOM traversal`,
+            );
+        }
     });
 }


### PR DESCRIPTION
GitHub wraps syntax-highlighted blocks in `div.highlight`, and neither skip map listed it, so the translator kept walking into highlighted code. This adds `.highlight` plus the conventional opt-out markers `.notranslate` and `[translate="no"]` to the `'*'` bucket of `ignoreSelectorPage` and `ignoreMutationSelectorPage` in both `locals.js` and `locals_zh-TW.js`. `getPageConfig()` already spreads that bucket into the TreeWalker filter and the MutationObserver, so a matching subtree is rejected before any term lookup runs, and users get a way to mark their own regions as untranslatable.

`test/issue-700-regression.test.cjs` now asserts all three selectors land in both maps for both locale files, next to the existing `article.markdown-body` check.

This covers the code-container and user-marked-region parts of the report. The separate over-translation of `and` and `on:` in English prose is a term-level question and is not touched here.

Refs #700
