### PR TITLE
feat: AI 代码审查工作流（DeepSeek，类 Copilot，自付额度）

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,139 @@
+name: AI 代码审查（DeepSeek）
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 目标仓库 owner/repo（默认本仓库）
+        required: false
+        default: ''
+      pr:
+        description: PR 编号
+        required: true
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '*/15 * * * *'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ai-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    env:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      GH_TOKEN: ${{ github.token }}
+      APP_ID: ${{ secrets.APP_ID }}
+      TARGET_REPO: ${{ vars.REVIEW_TARGET || 'maboloshi/github-chinese' }}
+      WATCHLIST: ${{ vars.REVIEW_WATCHLIST || '' }}
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/review'))
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 解析目标仓库、PR 与 head SHA
+        id: ctx
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            repo="${{ inputs.repo || github.repository }}"
+            pr="${{ inputs.pr }}"
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            repo="${{ github.repository }}"
+            pr="${{ github.event.issue.number }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            repo="${{ github.repository }}"
+            pr="${{ github.event.pull_request.number }}"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            repo="${TARGET_REPO:-maboloshi/github-chinese}"
+            owner="${{ github.repository_owner }}"
+            for p in ${WATCHLIST//,/ }; do
+              [ -z "$p" ] && continue
+              hit=$(gh api "repos/$repo/issues/$p/comments" \
+                --jq '[.[] | select(.user.login == $o) | select(.body | contains("/review"))] | length' \
+                --arg o "$owner" 2>/dev/null || echo 0)
+              if [ "$hit" != "0" ]; then
+                pr="$p"
+                break
+              fi
+            done
+          fi
+          if [ -z "$repo" ] || [ -z "$pr" ]; then
+            echo "本次无目标 PR（schedule 看护清单中无待审 /review），跳过。"
+            exit 0
+          fi
+          case "$repo" in
+            */*) ;;
+            *) echo "❌ repo 参数格式应为 owner/repo（当前：$repo）"; exit 1 ;;
+          esac
+          sha=$(gh api "repos/$repo/pulls/$pr" --jq '.head.sha' 2>/dev/null || echo "")
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "owner=${repo%%/*}" >> "$GITHUB_OUTPUT"
+          echo "repo_name=${repo#*/}" >> "$GITHUB_OUTPUT"
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: 去重（同一 head SHA 已审过则跳过）
+        id: dedup
+        if: steps.ctx.outputs.pr != ''
+        run: |
+          sha="${{ steps.ctx.outputs.sha }}"
+          if [ -z "$sha" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          comments=$(gh api "repos/${{ steps.ctx.outputs.repo }}/issues/${{ steps.ctx.outputs.pr }}/comments" --jq '.[].body' 2>/dev/null || true)
+          if printf '%s' "$comments" | grep -q "ai-review:$sha"; then
+            echo "该 head（$sha）已审查过，跳过。"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 生成 AI 审查
+        if: steps.ctx.outputs.pr != '' && steps.dedup.outputs.skip != 'true' && env.LLM_API_KEY != ''
+        env:
+          LLM_BASE_URL: ${{ secrets.LLM_BASE_URL || '' }}
+          LLM_MODEL: ${{ secrets.LLM_MODEL || '' }}
+        run: |
+          python script/ai_review.py \
+            --repo "${{ steps.ctx.outputs.repo }}" \
+            --pr "${{ steps.ctx.outputs.pr }}" \
+            --out review.md
+
+      - name: 生成 GitHub App 安装令牌（bot 身份）
+        id: app-token
+        if: steps.ctx.outputs.pr != '' && steps.dedup.outputs.skip != 'true' && env.LLM_API_KEY != '' && env.APP_ID != '' && success()
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ steps.ctx.outputs.owner }}
+          repositories: ${{ steps.ctx.outputs.repo_name }}
+
+      - name: 组装审查评论文件（追加去重标记）
+        if: steps.ctx.outputs.pr != '' && steps.dedup.outputs.skip != 'true' && env.LLM_API_KEY != '' && success()
+        run: |
+          printf '\n\n<!--ai-review:%s-->' "${{ steps.ctx.outputs.sha }}" >> review.md
+
+      - name: 发布审查评论（App bot 优先，否则 github-actions[bot]）
+        if: steps.ctx.outputs.pr != '' && steps.dedup.outputs.skip != 'true' && env.LLM_API_KEY != '' && success()
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          export GH_TOKEN="${APP_TOKEN:-${{ github.token }}}"
+          echo "以 bot 身份发布到 ${{ steps.ctx.outputs.repo }}#${{ steps.ctx.outputs.pr }}"
+          gh api "repos/${{ steps.ctx.outputs.repo }}/issues/${{ steps.ctx.outputs.pr }}/comments" -F "body=@review.md" --jq '.html_url'

--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -1,0 +1,73 @@
+# AI 代码审查（DeepSeek）— 使用说明
+
+本仓库内置一个"类 Copilot"的 AI 代码审查工作流：任何用户可**自动或按需**请求 DeepSeek 对 PR 进行中文代码审查，审查以**机器人身份**发布，**每次审查消耗请求者自己的 DeepSeek 额度**，仓库不保存任何密钥明文。
+
+## 如何工作
+
+```mermaid
+flowchart LR
+  U[用户] -- 提交/评论 PR 或 /review --> W[GitHub Actions<br/>本仓库/fork]
+  W -- 拉取 PR diff --> D
+  W -- 调用 DeepSeek（用请求者 LLM_API_KEY） --> D[(DeepSeek)]
+  W -- 机器人身份发布中文审查 --> P[PR]
+```
+
+- `script/ai_review.py`：拉取 PR 元数据与 diff → 读取 `.github/copilot-instructions.md`（强制中文）→ 调用 DeepSeek → 生成结构化审查（概览 / 问题分级 / 优点 / 重写建议）。
+- 发布身份：
+  - 默认：`github-actions[bot]`（无需任何额外配置）。
+  - 若配置了 GitHub App：以 `gh-chinese-ai-reviewer[bot]` 发布（可发布到任意已安装该 App 的仓库，含上游）。
+
+## 触发方式
+
+| 触发 | 说明 |
+|---|---|
+| `pull_request`（opened / synchronize / ready_for_review） | 打开或更新 PR 时自动审查（需工作流位于默认分支） |
+| 评论 `/review` | 在 PR 上评论 `/review` 即按需审查 |
+| `workflow_dispatch` | 手动指定 `repo` 与 `pr` 审查任意公开 PR |
+| `schedule`（每 15 分钟） | 轮询「看护清单」中的上游 PR，响应其中由本仓库属主发出的 `/review` |
+
+去重：同一 head SHA 只会审查一次（评论尾部 `<!--ai-review:<sha>-->` 标记）。
+
+## 配置（fork 自建实例）
+
+### Secrets（Settings → Secrets and variables → Actions）
+
+| 名称 | 必填 | 说明 |
+|---|---|---|
+| `LLM_API_KEY` | ✅ | 你的 DeepSeek API key（https://platform.deepseek.com/api_keys）。只存在你自己的 fork，明文从不出你侧 |
+| `APP_ID` | 可选 | 用于以 App 机器人身份发布（见下「GitHub App」） |
+| `APP_PRIVATE_KEY` | 可选 | GitHub App 私钥（`.pem` 全文） |
+| `LLM_BASE_URL` / `LLM_MODEL` | 可选 | 默认 `https://api.deepseek.com` / `deepseek-chat` |
+
+### Variables（可选，Step 2 轮询用）
+
+| 名称 | 说明 |
+|---|---|
+| `REVIEW_TARGET` | 轮询的目标仓库，默认 `maboloshi/github-chinese` |
+| `REVIEW_WATCHLIST` | 逗号分隔的 PR 号，如 `760,766`；只轮询这些 PR 上的 `/review` |
+
+### GitHub App（可选，bot 身份发布）
+
+1. https://github.com/settings/apps/new 创建 App（名称勿以 `GitHub`/`Gist` 开头）
+2. 权限：**Pull requests Read & write**、**Issues Write**；Webhook 可关；安装范围 **Any account**
+3. 生成私钥 `.pem`；把 `APP_ID`、`APP_PRIVATE_KEY` 配进 Secrets
+4. 安装到你自己的 fork（`Install App`）；发布到上游仓库时，请仓库维护者从 App 公共页 https://github.com/apps/<app-name> 安装
+
+## 安全模型
+
+- **任何人看不到明文**：DeepSeek key 只存在于请求者自己的 fork secret / 本地；上游仓库零密钥。
+- **自负额度**：每次审查只用触发者自己的 `LLM_API_KEY`（`secrets.LLM_API_KEY`）。
+- **bot 身份**：审查以 `github-actions[bot]` 或 GitHub App 机器人发布，不占用用户账号。
+- **提示词注入**：密钥绝不进入 prompt；模型输出只作为文本渲染，不执行。
+- **工作流安全**：不使用 `pull_request_target`；第三方 Action 建议钉版本；不打印密钥。
+- **已知限制**：
+  - 上游 `/review` 为**轮询**（约 15 分钟），非即时。
+  - fork PR 的 `pull_request` 事件**读不到 secrets** → fork 内 PR 自动审需要把工作流放到 fork 默认分支；上游 PR 的自动审依赖 fork 侧 `push` 反查或轮询。
+  - 发布到上游需仓库维护者安装 GitHub App（可随时撤销）。
+
+## 常见问题
+
+- **工作流没跑？** 确认工作流文件在**默认分支**（`issue_comment` / `schedule` / `workflow_dispatch` 只在默认分支触发）。
+- **提示缺 `LLM_API_KEY`？** 在 fork 的 Secrets 添加。
+- **`/review` 没反应？** 轮询有延迟（≤15 分钟）；确认该 PR 在 `REVIEW_WATCHLIST` 中（若配置）。
+- **想只审一次？** 去重按 head SHA，同一提交不会重复审查。

--- a/script/ai_review.py
+++ b/script/ai_review.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+AI 代码审查（DeepSeek）—— 生成结构化中文审查。
+用法：
+  python script/ai_review.py --repo <owner/repo> --pr <number> [--mode full|summary] [--out file.md]
+输出：审查 Markdown（默认 stdout，--out 写文件）。
+环境变量：
+  LLM_API_KEY  必填（DeepSeek API key）
+  LLM_BASE_URL 可选，默认 https://api.deepseek.com
+  LLM_MODEL    可选，默认 deepseek-chat
+"""
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.request
+import urllib.error
+
+
+def fetch(url: str, headers: dict | None = None, retries: int = 3) -> str:
+    """拉取 URL；对 5xx / 网络错误做指数退避重试。"""
+    req = urllib.request.Request(
+        url, headers=headers or {"User-Agent": "github-chinese-ai-review"}
+    )
+    last_err = ""
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as r:
+                return r.read().decode("utf-8")
+        except urllib.error.HTTPError as e:
+            last_err = f"HTTP {e.code}"
+            if e.code < 500:  # 4xx 不重试
+                raise
+        except Exception as e:  # noqa: BLE001 - 网络层异常统一重试
+            last_err = str(e)
+        time.sleep(2 * (attempt + 1))
+    raise RuntimeError(f"请求失败（重试 {retries} 次后仍失败）：{last_err}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="AI 代码审查（DeepSeek）")
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--pr", required=True, help="PR 编号")
+    parser.add_argument("--mode", choices=["full", "summary"], default="full")
+    parser.add_argument("--out", help="输出文件（默认 stdout）")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("LLM_API_KEY")
+    if not api_key:
+        print("❌ 缺少环境变量 LLM_API_KEY", file=sys.stderr)
+        sys.exit(1)
+
+    # 1) PR 元数据 + diff
+    try:
+        pr_meta = json.loads(fetch(f"https://api.github.com/repos/{args.repo}/pulls/{args.pr}"))
+    except Exception as e:  # noqa: BLE001
+        print(f"❌ 无法获取 PR 信息：{e}", file=sys.stderr)
+        sys.exit(1)
+    title = pr_meta.get("title", "")
+    body = (pr_meta.get("body") or "")[:2000]
+    base, head = pr_meta["base"]["ref"], pr_meta["head"]["ref"]
+    try:
+        diff = fetch(f"https://github.com/{args.repo}/pull/{args.pr}.diff")
+    except Exception as e:  # noqa: BLE001
+        print(f"❌ 无法获取 PR diff：{e}", file=sys.stderr)
+        sys.exit(1)
+    if len(diff) > 60000:
+        diff = diff[:60000] + "\n...(diff 过长已截断)"
+
+    # 2) 仓库审查规范（强制中文回复）
+    instructions = ""
+    try:
+        instructions = fetch(
+            f"https://raw.githubusercontent.com/{args.repo}/HEAD/.github/copilot-instructions.md"
+        )
+    except Exception:
+        pass
+
+    # 3) 组装 prompt
+    system = (
+        "你是一名资深代码审查员。请务必用简体中文输出审查意见。\n" + instructions
+    )
+    scope = "请重点审查核心逻辑、正确性、安全与可维护性，给出精炼结论。"
+    if args.mode == "summary":
+        scope = "请只输出简短摘要（3-5 行）：变更目的、主要风险、是否建议合并。"
+    user = f"""请审查拉取请求 #{args.pr}「{title}」（{base} → {head}）。
+
+PR 描述：
+{body}
+
+变更 diff：
+```diff
+{diff}
+```
+
+{scope}
+
+完整输出请用如下 Markdown 结构：
+## 概览
+一句话结论 + 变更规模/重点。
+## 发现的问题
+按严重度分组（🔴 阻断 / 🟠 重要 / 🟡 建议 / 🔵 nit），每条尽量给出「文件:行号 + 问题 + 修改建议」。
+## 优点
+值得肯定的点。
+## 重写/改进建议（必要时）
+对明显可简化的逻辑给出具体改法；若无需重写则省略本节。
+若 diff 为空或无可审内容，请如实说明。"""
+
+    # 4) 调用 DeepSeek
+    base_url = os.environ.get("LLM_BASE_URL") or "https://api.deepseek.com"
+    model = os.environ.get("LLM_MODEL") or "deepseek-chat"
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "temperature": 0.2,
+        "stream": False,
+    }
+    req = urllib.request.Request(
+        f"{base_url}/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=180) as r:
+            resp = json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        print(f"❌ DeepSeek 调用失败：{e.code} {e.read().decode('utf-8')[:500]}", file=sys.stderr)
+        sys.exit(1)
+
+    choices = resp.get("choices") or []
+    if not choices:
+        print("❌ DeepSeek 返回空 choices（可能被内容过滤或额度/余额不足）", file=sys.stderr)
+        sys.exit(1)
+    content = choices[0].get("message", {}).get("content", "")
+    review = (
+        f"## 🤖 AI 审查（DeepSeek）— PR #{args.pr}\n\n{content}\n\n"
+        "---\n*由 `script/ai_review.py` 生成，使用请求者自己的 DeepSeek 额度。*"
+    )
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(review)
+        print(f"✅ 审查已写入 {args.out}", file=sys.stderr)
+    else:
+        print(review)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 简介

新增一个"类 Copilot"的 AI 代码审查工作流：任何用户可以**自动或按需**请求 DeepSeek 对 PR 进行中文代码审查，审查以**机器人身份**发布，**每次审查消耗请求者自己的 DeepSeek 额度**，本仓库**不保存任何密钥明文**。

## 变更内容

- `.github/workflows/ai-review.yml`
  - `pull_request` 打开/更新时自动审查
  - PR 评论 `/review` 按需审查
  - `workflow_dispatch` 手动指定仓库+PR
  - `schedule` 轮询「看护清单」中的上游 PR，响应本仓库属主的 `/review`
  - 去重：同一 head SHA 只审一次
- `script/ai_review.py`：拉取 PR diff → 读取 `.github/copilot-instructions.md`（强制中文）→ 调用 DeepSeek → 输出结构化审查（概览/问题分级/优点/重写建议）
- `docs/ai-review.md`：使用与安全模型说明

## 设计要点与安全模型

- **自付额度**：密钥 `LLM_API_KEY` 只存在于用户自己的 fork secret；每次审查只花触发者自己的 DeepSeek 额度。**上游仓库不存任何密钥。**
- **bot 身份**：默认以 `github-actions[bot]` 发布；配置 GitHub App 后以机器人（如 `gh-chinese-ai-reviewer[bot]`）发布，不占用用户账号。
- **任何人看不到明文**：密钥明文只在用户侧进程。
- 不使用 `pull_request_target`；模型输出仅作为文本渲染，不执行。
- 各用户在**自己的 fork** 启用（复制工作流+脚本，配置 secrets）；本仓库的工作流在没有配置时自动跳过（不产生副作用）。

## 已知限制

- 上游 `/review` 为**轮询**（约 15 分钟），非即时。
- fork PR 的 `pull_request` 事件读不到 secrets → fork 内自动审需把工作流放到 fork 默认分支。
- 若希望机器人直接在本仓库发布，需由维护者从 App 公共页安装该 GitHub App（可随时撤销）。

## 验证

已在 fork `PtJade-Ceramic/github-chinese` 端到端验证：自动审、`/review`、`workflow_dispatch`、去重、`github-actions[bot]` 与 `gh-chinese-ai-reviewer[bot]` 发布均通过。