### PR TITLE
修复 Star History 图表：切换至 star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,11 +401,11 @@ GitHub 的 ajax 载入方式逐步从 [defunkt/jquery-pjax](https://github.com/d
 
 ## 📈 项目统计
 
-<a href="https://star-history.com/#maboloshi/github-chinese&Timeline">
+<a href="https://star-history.dera.page/#maboloshi/github-chinese&Timeline">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=maboloshi/github-chinese&type=Timeline&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=maboloshi/github-chinese&type=Timeline" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=maboloshi/github-chinese&type=Timeline" width="75%" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=maboloshi/github-chinese&type=Timeline&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=maboloshi/github-chinese&type=Timeline" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=maboloshi/github-chinese&type=Timeline" width="75%" />
   </picture>
 </a>
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -378,11 +378,11 @@ GitHub 的 ajax 載入方式逐步從 [defunkt/jquery-pjax](https://github.com/d
 
 ## 📈 項目統計
 
-<a href="https://star-history.com/#maboloshi/github-chinese&Timeline">
+<a href="https://star-history.dera.page/#maboloshi/github-chinese&Timeline">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=maboloshi/github-chinese&type=Timeline&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=maboloshi/github-chinese&type=Timeline" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=maboloshi/github-chinese&type=Timeline" width="75%" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=maboloshi/github-chinese&type=Timeline&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=maboloshi/github-chinese&type=Timeline" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=maboloshi/github-chinese&type=Timeline" width="75%" />
   </picture>
 </a>
 


### PR DESCRIPTION
当前项目统计中的 Star History 图表因 GitHub stargazer API 限制而无法正常显示。

本 PR 将图表链接切换到 star-history.dera.page，其使用无需 API token 的替代数据源，与前端使用同一域名，可正常渲染图表且无需额外配置。

The current Star History chart is broken due to GitHub stargazer API restrictions. This PR switches the chart links to star-history.dera.page, which uses an alternative data source requiring no API token, so the chart renders correctly again.