### PR TITLE
fix: prevent translation of editable content

### DIFF
--- a/locals.js
+++ b/locals.js
@@ -115,6 +115,11 @@ I18N.conf = {
             '.highlight',
             '.notranslate',
             '[translate="no"]',
+            'input',
+            'textarea',
+            '[contenteditable=""]',
+            '[contenteditable="true"]',
+            '[contenteditable="plaintext-only"]',
             'div.QueryBuilder-StyledInputContainer', // 顶部搜索栏 关键词
             '#qb-input-query span', // 搜索页面 搜索栏 关键词
 			'div.styled-input-content', // 筛选条
@@ -254,6 +259,11 @@ I18N.conf = {
             '.highlight',
             '.notranslate',
             '[translate="no"]',
+            'input',
+            'textarea',
+            '[contenteditable=""]',
+            '[contenteditable="true"]',
+            '[contenteditable="plaintext-only"]',
 			'div.styled-input-content', // 筛选条
         ],
     },

--- a/test/issue-727-regression.test.cjs
+++ b/test/issue-727-regression.test.cjs
@@ -1,0 +1,38 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const editableSelectors = [
+    'input',
+    'textarea',
+    '[contenteditable=""]',
+    '[contenteditable="true"]',
+    '[contenteditable="plaintext-only"]',
+];
+
+function loadConfig() {
+    const filePath = `${__dirname}/../locals.js`;
+    const context = vm.createContext({});
+
+    vm.runInContext(fs.readFileSync(filePath, 'utf8'), context, {
+        filename: filePath,
+    });
+
+    return context.I18N.conf;
+}
+
+test('locals.js keeps editable content out of translation', () => {
+    const config = loadConfig();
+
+    for (const selector of editableSelectors) {
+        assert.ok(
+            config.ignoreMutationSelectorPage['*'].includes(selector),
+            `${selector} must be ignored by MutationObserver translation`,
+        );
+        assert.ok(
+            config.ignoreSelectorPage['*'].includes(selector),
+            `${selector} must be ignored during the initial DOM traversal`,
+        );
+    }
+});


### PR DESCRIPTION
Extend the global entries in both `ignoreMutationSelectorPage['*']` and `ignoreSelectorPage['*']` so editable controls and contenteditable regions are excluded regardless of the GitHub page or editor implementation. Issue #727 reports that text being edited on GitHub can sometimes be translated automatically, corrupting user-authored code or prose.

Verify `input`, `textarea`, and enabled contenteditable selectors are present in the global mutation exclusion list, so newly typed or dynamically inserted user content is never sent through translation; Verify the same selectors are present in the global initial-traversal exclusion list, so content already in an editor when the script starts remains unchanged.

Closes #727
