### PR TITLE
fix(issue-778): 忽略 PR 提交消息区域

### DIFF
--- a/locals(greasyfork).js
+++ b/locals(greasyfork).js
@@ -63,6 +63,11 @@ I18N.conf = {
         'repository/pull': [
             "td.blob-code", // 代码差异 分屏/同屏
             '.js-full-logs-container', // 工作流运行日志
+            'div.commit-title', // 提交标题（经典 UI）
+            'div.commit-desc', // 提交说明（经典 UI）
+            'span.ws-pre-wrap', // 提交说明
+            "h4[class^='Title-module__heading']", // 提交标题
+            'div[class^="CommitHeader-module__commitMessageContainer"]', // PR changes 页提交消息容器
         ],
         'repository/compare': [
             "tbody", // 代码差异
@@ -174,6 +179,11 @@ I18N.conf = {
         'repository/pull': [
             'td.blob-code', // 代码差异 分屏/同屏
             '.js-full-logs-container', // 工作流运行日志
+            'div.commit-title', // 提交标题（经典 UI）
+            'div.commit-desc', // 提交说明（经典 UI）
+            'span.ws-pre-wrap', // 提交说明
+            "h4[class^='Title-module__heading']", // 提交标题
+            'div[class^="CommitHeader-module__commitMessageContainer"]', // PR changes 页提交消息容器
         ],
         'repository/compare': [
             'td.blob-code', // 代码差异 分屏/同屏

--- a/locals.js
+++ b/locals.js
@@ -65,6 +65,11 @@ I18N.conf = {
             '.js-full-logs-container', // 工作流运行日志
             'span.PRIVATE_TreeView-item-content-text', // 文件树文件夹/文件名
             'span.ActionList-item-label', // PR 文件树文件夹/文件名
+            'div.commit-title', // 提交标题（经典 UI）
+            'div.commit-desc', // 提交说明（经典 UI）
+            'span.ws-pre-wrap', // 提交说明
+            "h4[class^='Title-module__heading']", // 提交标题
+            'div[class^="CommitHeader-module__commitMessageContainer"]', // PR changes 页提交消息容器
         ],
         'repository/compare': [
             "tbody", // 代码差异
@@ -189,6 +194,11 @@ I18N.conf = {
             '.js-full-logs-container', // 工作流运行日志
             'span.PRIVATE_TreeView-item-content-text', // 文件树文件夹/文件名
             'span.ActionList-item-label', // PR 文件树文件夹/文件名
+            'div.commit-title', // 提交标题（经典 UI）
+            'div.commit-desc', // 提交说明（经典 UI）
+            'span.ws-pre-wrap', // 提交说明
+            "h4[class^='Title-module__heading']", // 提交标题
+            'div[class^="CommitHeader-module__commitMessageContainer"]', // PR changes 页提交消息容器
         ],
         'repository/compare': [
             'td.blob-code', // 代码差异 分屏/同屏
@@ -10072,7 +10082,7 @@ I18N["zh-CN"]["repository/issues"] = { // 仓库 - 议题页面
             "Filter authors": "筛选作者",
             "Filter by assignees": "筛选受理人",
                 "No assignees": "无人受理",
-            
+
             // 左侧栏
             "Assigned to me": "分配给您",
             "Created by me": "由您创建",
@@ -24726,7 +24736,7 @@ I18N["zh-CN"]["orgs/people"] = { // 组织 - 成员标签卡
             [/Pending Members · People/, "待处理成员"],
             [/Members · People/, "成员"],
             [/Outside Collaborators · People/, "外部协作者 · 成员"],
-            [/Pending Collaborators · People/, "待定协作者 · 成员"], 
+            [/Pending Collaborators · People/, "待定协作者 · 成员"],
             [/Failed Invitations · People/, "失败邀请 · 成员"],
             [/Security Managers for/, "安全管理员"],
         ],

--- a/locals_zh-TW.js
+++ b/locals_zh-TW.js
@@ -63,6 +63,11 @@ I18N.conf = {
         'repository/pull': [
             "td.blob-code", // 程式碼差異 分屏/同屏
             '.js-full-logs-container', // 工作流執行日誌
+            'div.commit-title', // 提交標題（經典 UI）
+            'div.commit-desc', // 提交說明（經典 UI）
+            'span.ws-pre-wrap', // 提交說明
+            "h4[class^='Title-module__heading']", // 提交標題
+            'div[class^="CommitHeader-module__commitMessageContainer"]', // PR changes 頁提交訊息容器
         ],
         'repository/compare': [
             "tbody", // 程式碼差異
@@ -174,6 +179,11 @@ I18N.conf = {
         'repository/pull': [
             'td.blob-code', // 程式碼差異 分屏/同屏
             '.js-full-logs-container', // 工作流執行日誌
+            'div.commit-title', // 提交標題（經典 UI）
+            'div.commit-desc', // 提交說明（經典 UI）
+            'span.ws-pre-wrap', // 提交說明
+            "h4[class^='Title-module__heading']", // 提交標題
+            'div[class^="CommitHeader-module__commitMessageContainer"]', // PR changes 頁提交訊息容器
         ],
         'repository/compare': [
             'td.blob-code', // 程式碼差異 分屏/同屏

--- a/test/helpers/load-config.cjs
+++ b/test/helpers/load-config.cjs
@@ -1,0 +1,24 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+/**
+ * 从仓库根目录加载一个语言配置文件，并返回其 I18N.conf。
+ *
+ * @param {string} fileName  相对于仓库根目录的路径（如 'locals.js'）。
+ * @returns {object} 解析后的 I18N.conf 对象。
+ */
+function loadConfig(fileName) {
+    const filePath = path.join(__dirname, '..', '..', fileName);
+    const context = vm.createContext({});
+
+    vm.runInContext(fs.readFileSync(filePath, 'utf8'), context, {
+        filename: filePath,
+    });
+
+    return context.I18N.conf;
+}
+
+module.exports = { loadConfig };

--- a/test/issue-700-regression.test.cjs
+++ b/test/issue-700-regression.test.cjs
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
 const test = require('node:test');
-const vm = require('node:vm');
+
+const { loadConfig } = require('./helpers/load-config.cjs');
 
 const localeFiles = [
     'locals.js',
@@ -12,17 +12,6 @@ const globalTranslationSkipSelectors = [
     '.notranslate',
     '[translate="no"]',
 ];
-
-function loadConfig(fileName) {
-    const filePath = `${__dirname}/../${fileName}`;
-    const context = vm.createContext({});
-
-    vm.runInContext(fs.readFileSync(filePath, 'utf8'), context, {
-        filename: filePath,
-    });
-
-    return context.I18N.conf;
-}
 
 test('locals.js keeps repository tree README content out of translation', () => {
     const config = loadConfig('locals.js');

--- a/test/issue-702-regression.test.cjs
+++ b/test/issue-702-regression.test.cjs
@@ -4,6 +4,8 @@ const path = require('node:path');
 const test = require('node:test');
 const vm = require('node:vm');
 
+const { loadConfig } = require('./helpers/load-config.cjs');
+
 const localeFiles = [
     'locals.js',
     'locals(greasyfork).js',
@@ -220,17 +222,6 @@ const expectedReactNavLabels = {
         },
     },
 };
-
-function loadConfig(fileName) {
-    const filePath = path.join(__dirname, '..', fileName);
-    const context = vm.createContext({});
-
-    vm.runInContext(fs.readFileSync(filePath, 'utf8'), context, {
-        filename: filePath,
-    });
-
-    return context.I18N.conf;
-}
 
 function loadLocale(fileName, localeName) {
     const filePath = path.join(__dirname, '..', fileName);

--- a/test/issue-761-regression.test.cjs
+++ b/test/issue-761-regression.test.cjs
@@ -93,7 +93,8 @@ class Element {
 
 function loadGlobalNavTranslation(document) {
     const filePath = path.join(__dirname, '..', 'main.user.js');
-    const source = fs.readFileSync(filePath, 'utf8');
+    // 归一化 CRLF -> LF，保证 \n\n 标记在 Windows 检出（core.autocrlf）下也能匹配
+    const source = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
     const start = source.indexOf('    function setupReactGlobalNavTranslation(');
     const end = source.indexOf('\n\n    /* =========================== MutationObserver', start);
     assert.notEqual(start, -1);

--- a/test/issue-778-regression.test.cjs
+++ b/test/issue-778-regression.test.cjs
@@ -1,0 +1,31 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { loadConfig } = require('./helpers/load-config.cjs');
+
+for (const fileName of [
+    'locals.js',
+    'locals_zh-TW.js',
+    'locals(greasyfork).js',
+]) {
+    test(`${fileName} completely skips pull-request commit messages`, () => {
+        const config = loadConfig(fileName);
+
+        for (const selector of [// 提交消息区域的忽略选择器（经典 UI + 新版 React，与 repository/commit 一致 + 容器加固）
+            'div.commit-title',                                          // 提交标题（经典 UI）
+            'div.commit-desc',                                           // 提交说明（经典 UI）
+            'span.ws-pre-wrap',                                          // 提交说明（新版）
+            "h4[class^='Title-module__heading']",                        // 提交标题（新版）
+            'div[class^="CommitHeader-module__commitMessageContainer"]', // PR changes 页提交消息容器
+        ]) {
+            assert.ok(
+                config.ignoreMutationSelectorPage['repository/pull'].includes(selector),
+                `${selector} must be ignored by MutationObserver translation`,
+            );
+            assert.ok(
+                config.ignoreSelectorPage['repository/pull'].includes(selector),
+                `${selector} must be ignored during the initial DOM traversal`,
+            );
+        }
+    });
+}


### PR DESCRIPTION
本提交
- locals: repository/pull 忽略选择器补充经典 UI（div.commit-title/div.commit-desc）与新版 React（CommitHeader-module 容器），避免提交消息被误翻译（fixes #778）
- test: 抽取共用 test/helpers/load-config.cjs，统一 issue-700/702/761/778 测试结构