### PR TITLE
fix: prevent stable relative times from treating minutes as months

### DIFF
--- a/main(greasyfork).user.js
+++ b/main(greasyfork).user.js
@@ -469,14 +469,9 @@
         if (node.nodeType === Node.ELEMENT_NODE) { // 元素节点处理
 
             // 翻译时间元素
-            if (
-                ["RELATIVE-TIME", "TIME-AGO", "TIME", "LOCAL-TIME"].includes(node.tagName)
-            ) {
+            if (node.tagName === "RELATIVE-TIME") {
                 if (node.shadowRoot) {
                     transTimeElement(node.shadowRoot);
-                    watchTimeElement(node.shadowRoot);
-                } else {
-                    transTimeElement(node);
                 }
                 return;
             }
@@ -623,33 +618,13 @@
      * @param {Element} el - 需要翻译的元素。
      */
     function transTimeElement(el) {
-        let key = el.childNodes.length > 0 ? el.lastChild.textContent : el.textContent;
-        let res = I18N[lang]['public']['time-regexp']; // 时间正则规则
-
-        for (let [a, b] of res) {
-            let str = key.replace(a, b);
-            if (str !== key) {
-                el.textContent = str;
-                break;
-            }
+        const text = el.textContent;
+        if (!text) return;
+        // 移除开头的"on"
+        const result = text.replace(/^on/, "");
+        if (result !== text) {
+            el.textContent = result;
         }
-    }
-
-    /**
-     * watchTimeElement 函数：监视时间元素变化, 触发和调用时间元素翻译
-     * @param {Element} el - 需要监视的元素。
-     */
-    function watchTimeElement(el) {
-        const MutationObserver =
-            window.MutationObserver ||
-            window.WebKitMutationObserver ||
-            window.MozMutationObserver;
-
-        new MutationObserver(mutations => {
-            transTimeElement(mutations[0].addedNodes[0]);
-        }).observe(el, {
-            childList: true
-        });
     }
 
     /**
@@ -842,10 +817,28 @@
     }
 
     /**
+     * 初始化并保护中文语言环境
+     */
+    function initLangEnv() {
+        // 设置初始语言
+        document.documentElement.lang = 'zh-CN';
+
+        // 监视语言属性变化，防止被改回英文
+        const langObserver = new MutationObserver(() => {
+            // 如果检测到语言被改回英文，重新设置
+            if (document.documentElement.lang === "en") {
+                document.documentElement.lang = 'zh-CN';
+            }
+        });
+        langObserver.observe(document.documentElement, { attributeFilter: ['lang'] });
+    }
+
+    /**
      * init 函数：初始化翻译功能。
      */
     function init() {
         setupReactGlobalNavTranslation();
+        initLangEnv();
 
         // 获取当前页面的翻译规则
         page = getPage();

--- a/test/issue-785-regression.test.cjs
+++ b/test/issue-785-regression.test.cjs
@@ -1,0 +1,198 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ELEMENT_NODE = 1;
+
+function extractFunction(source, name) {
+    const start = source.indexOf(`    function ${name}(`);
+    assert.notEqual(start, -1, `${name} should exist in the stable userscript`);
+
+    const bodyStart = source.indexOf('{', start);
+    let depth = 0;
+
+    for (let index = bodyStart; index < source.length; index += 1) {
+        if (source[index] === '{') depth += 1;
+        if (source[index] === '}') depth -= 1;
+        if (depth === 0) return source.slice(start, index + 1);
+    }
+
+    assert.fail(`could not extract ${name} from the stable userscript`);
+}
+
+function loadStableTimeTranslation() {
+    const filePath = path.join(__dirname, '..', 'main(greasyfork).user.js');
+    const source = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+    const observers = [];
+    let timeRuleReads = 0;
+
+    class MutationObserver {
+        constructor(callback) {
+            this.callback = callback;
+            this.target = null;
+            this.config = null;
+            observers.push(this);
+        }
+
+        observe(target, config) {
+            this.target = target;
+            this.config = config;
+        }
+    }
+
+    const document = {
+        body: {},
+        documentElement: { lang: 'en' },
+    };
+    const publicRules = {};
+    Object.defineProperty(publicRules, 'time-regexp', {
+        get() {
+            timeRuleReads += 1;
+            return [[/^(\d+)m ago$/, '$1个月前']];
+        },
+    });
+
+    const context = vm.createContext({
+        console: { log() {} },
+        document,
+        getPage: () => false,
+        I18N: {
+            conf: {
+                reIgnoreId: /$a/,
+                reIgnoreClass: /$a/,
+                reIgnoreTag: [],
+                reIgnoreItemprop: /$a/,
+            },
+            'zh-CN': { public: publicRules },
+        },
+        lang: 'zh-CN',
+        MutationObserver,
+        Node: { ELEMENT_NODE, TEXT_NODE: 3 },
+        page: false,
+        registerMenuCommand() {},
+        setTimeout() {},
+        setupReactGlobalNavTranslation() {},
+        transBySelector() {},
+        transDesc() {},
+        transElement() {},
+        transTitle() {},
+        watchUpdate() {},
+        window: { MutationObserver },
+    });
+    const functions = [
+        'initLangEnv',
+        'transTimeElement',
+        'traverseNode',
+        'init',
+    ].map(name => extractFunction(source, name)).join('\n\n');
+    const api = vm.runInContext(
+        `(function () {\n${functions}\nreturn { init, transTimeElement, traverseNode };\n})()`,
+        context,
+        { filename: filePath },
+    );
+
+    return {
+        ...api,
+        document,
+        observers,
+        getTimeRuleReads: () => timeRuleReads,
+    };
+}
+
+function createRelativeTime(text) {
+    let value = text;
+    const shadowRoot = {
+        childNodes: [{}],
+        get lastChild() {
+            return { textContent: value };
+        },
+        get textContent() {
+            return value;
+        },
+        set textContent(nextValue) {
+            value = nextValue;
+        },
+    };
+
+    return {
+        nodeType: ELEMENT_NODE,
+        tagName: 'RELATIVE-TIME',
+        id: '',
+        className: '',
+        childNodes: [],
+        getAttribute() {
+            return null;
+        },
+        shadowRoot,
+    };
+}
+
+test('stable initialization selects and protects the zh-CN document language', () => {
+    const stable = loadStableTimeTranslation();
+
+    stable.init();
+
+    assert.equal(stable.document.documentElement.lang, 'zh-CN');
+    assert.equal(stable.observers.length, 1);
+    assert.equal(stable.observers[0].target, stable.document.documentElement);
+    assert.deepEqual(Array.from(stable.observers[0].config.attributeFilter), ['lang']);
+
+    stable.document.documentElement.lang = 'en';
+    stable.observers[0].callback();
+
+    assert.equal(stable.document.documentElement.lang, 'zh-CN');
+});
+
+test('leaves compact relative minutes to GitHub localization', () => {
+    const stable = loadStableTimeTranslation();
+    const relativeTime = createRelativeTime('3m ago');
+
+    stable.traverseNode(relativeTime);
+
+    assert.equal(relativeTime.shadowRoot.textContent, '3m ago');
+    assert.equal(stable.getTimeRuleReads(), 0);
+});
+
+test('limits time handling to RELATIVE-TIME shadow roots', () => {
+    const stable = loadStableTimeTranslation();
+    const legacyTime = createRelativeTime('on Sep 5, 2026');
+    legacyTime.tagName = 'TIME-AGO';
+    const shadowlessRelativeTime = createRelativeTime('on Sep 5, 2026');
+    shadowlessRelativeTime.shadowRoot = null;
+    shadowlessRelativeTime.textContent = 'on Sep 5, 2026';
+
+    stable.traverseNode(legacyTime);
+    stable.traverseNode(shadowlessRelativeTime);
+
+    assert.equal(legacyTime.shadowRoot.textContent, 'on Sep 5, 2026');
+    assert.equal(shadowlessRelativeTime.textContent, 'on Sep 5, 2026');
+});
+
+test('does not install an observer that races GitHub relative-time updates', () => {
+    const stable = loadStableTimeTranslation();
+    const relativeTime = createRelativeTime('3m ago');
+    stable.init();
+
+    stable.traverseNode(relativeTime);
+    relativeTime.shadowRoot.textContent = '2m ago';
+    stable.observers
+        .filter(observer => observer.target === relativeTime.shadowRoot)
+        .forEach(observer => observer.callback([{
+            addedNodes: [relativeTime.shadowRoot],
+        }]));
+
+    assert.equal(stable.observers.length, 1);
+    assert.equal(relativeTime.shadowRoot.textContent, '2m ago');
+});
+
+test('continues to remove only the leading on from absolute time text', () => {
+    const stable = loadStableTimeTranslation();
+    const relativeTime = createRelativeTime('on Sep 5, 2026');
+
+    stable.traverseNode(relativeTime);
+
+    assert.equal(relativeTime.shadowRoot.textContent, ' Sep 5, 2026');
+    assert.equal(stable.getTimeRuleReads(), 0);
+});


### PR DESCRIPTION
Backport the established relative-time behavior from `main.user.js` into `main(greasyfork).user.js` without porting the broader v1.9.4 refactor. Stable userscript version 1.9.2.4 rewrites GitHub's compact relative timestamps, so a value such as `3m ago` can be interpreted as three months rather than three minutes.

Initialize the stable userscript with an English document language and verify it selects `zh-CN`, allowing GitHub's component to localize compact relative units; Present a `RELATIVE-TIME` shadow root containing `3m ago` and verify the stable path does not rewrite `m` as months through `public.time-regexp`.

Fixes #785
